### PR TITLE
Fix 13 pre-existing clippy warnings (unblocks CI)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2009,11 +2009,11 @@ fn percent_decode(input: &str) -> String {
                 let hi = bytes.next().unwrap_or(b'0');
                 let lo = bytes.next().unwrap_or(b'0');
                 let hex = [hi, lo];
-                if let Ok(s) = std::str::from_utf8(&hex) {
-                    if let Ok(val) = u8::from_str_radix(s, 16) {
-                        out.push(val);
-                        continue;
-                    }
+                if let Ok(s) = std::str::from_utf8(&hex)
+                    && let Ok(val) = u8::from_str_radix(s, 16)
+                {
+                    out.push(val);
+                    continue;
                 }
                 out.push(b'%');
                 out.push(hi);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -62,7 +62,7 @@ pub enum LayoutVariant {
 
 impl LayoutVariant {
     /// Parse from the snake_case string used in `display.toml`.
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn from_name(s: &str) -> Option<Self> {
         match s {
             "full" => Some(Self::Full),
             "half_horizontal" => Some(Self::HalfHorizontal),
@@ -132,7 +132,7 @@ impl DisplayConfiguration {
             .iter()
             .enumerate()
             .map(|(i, s)| {
-                let variant = LayoutVariant::from_str(&s.variant).ok_or_else(|| {
+                let variant = LayoutVariant::from_name(&s.variant).ok_or_else(|| {
                     CompositorError::InvalidVariant { variant: s.variant.clone() }
                 })?;
                 let (default_w, default_h) = variant.canonical_dimensions();
@@ -165,16 +165,16 @@ impl DisplayConfiguration {
             .items
             .iter()
             .filter_map(|item| {
-                if let LayoutItem::PluginSlot { layout_variant, plugin_instance_id, .. } = item {
-                    if LayoutVariant::from_str(layout_variant).is_none() {
-                        log::warn!(
-                            "layout '{}': unknown variant '{}' for slot '{}', skipping",
-                            layout.id,
-                            layout_variant,
-                            plugin_instance_id
-                        );
-                        return None;
-                    }
+                if let LayoutItem::PluginSlot { layout_variant, plugin_instance_id, .. } = item
+                    && LayoutVariant::from_name(layout_variant).is_none()
+                {
+                    log::warn!(
+                        "layout '{}': unknown variant '{}' for slot '{}', skipping",
+                        layout.id,
+                        layout_variant,
+                        plugin_instance_id
+                    );
+                    return None;
                 }
                 Some(item.clone())
             })
@@ -267,7 +267,7 @@ impl Compositor {
                     plugin_instance_id,
                     layout_variant,
                     ..
-                } => match LayoutVariant::from_str(layout_variant) {
+                } => match LayoutVariant::from_name(layout_variant) {
                     None => {
                         // Filtered by from_layout_config; warn and skip if somehow reached.
                         log::warn!(
@@ -986,9 +986,9 @@ mod tests {
             ("quadrant", LayoutVariant::Quadrant),
         ];
         for (s, expected) in cases {
-            assert_eq!(LayoutVariant::from_str(s), Some(expected));
+            assert_eq!(LayoutVariant::from_name(s), Some(expected));
         }
-        assert_eq!(LayoutVariant::from_str("bogus"), None);
+        assert_eq!(LayoutVariant::from_name("bogus"), None);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -336,22 +336,22 @@ pub struct SecretsConfig {
 /// Load secrets from `path`.  If the file is absent or corrupt, a new random
 /// API key is generated, logged, and written to `path`.  Never fails.
 pub fn load_or_create_secrets(path: &Path) -> SecretsConfig {
-    if path.exists() {
-        if let Ok(contents) = std::fs::read_to_string(path) {
-            if let Ok(s) = toml::from_str::<SecretsConfig>(&contents) {
-                return s;
-            }
-            log::warn!("config/secrets.toml is corrupt — regenerating API key");
+    if path.exists()
+        && let Ok(contents) = std::fs::read_to_string(path)
+    {
+        if let Ok(s) = toml::from_str::<SecretsConfig>(&contents) {
+            return s;
         }
+        log::warn!("config/secrets.toml is corrupt — regenerating API key");
     }
     let api_key = generate_api_key();
     log::info!("Cascades API key: {}", api_key);
     eprintln!("Cascades API key: {}", api_key);
     let secrets = SecretsConfig { api_key };
-    if let Some(parent) = path.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).ok();
-        }
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent).ok();
     }
     if let Ok(toml_str) = toml::to_string_pretty(&secrets) {
         std::fs::write(path, toml_str).ok();
@@ -367,10 +367,10 @@ fn generate_api_key() -> String {
 
 fn fill_random(buf: &mut [u8]) {
     use std::io::Read;
-    if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
-        if f.read_exact(buf).is_ok() {
-            return;
-        }
+    if let Ok(mut f) = std::fs::File::open("/dev/urandom")
+        && f.read_exact(buf).is_ok()
+    {
+        return;
     }
     // Fallback: mix monotonic time + PID.
     let t = std::time::SystemTime::now()

--- a/src/format.rs
+++ b/src/format.rs
@@ -60,10 +60,10 @@ fn evaluate_expr(expr: &str, raw_value: &str) -> String {
 /// Apply a single filter to a string value.
 fn apply_filter(filter: &str, value: &str) -> String {
     if let Some(rest) = filter.strip_prefix("round(") {
-        if let Some(n_str) = rest.strip_suffix(')') {
-            if let Ok(n) = n_str.trim().parse::<u32>() {
-                return apply_round(value, n);
-            }
+        if let Some(n_str) = rest.strip_suffix(')')
+            && let Ok(n) = n_str.trim().parse::<u32>()
+        {
+            return apply_round(value, n);
         }
         return value.to_string();
     }
@@ -100,8 +100,8 @@ fn apply_number_with_delimiter(value: &str) -> String {
     };
 
     // Handle negative numbers
-    let (sign, digits) = if integer_part.starts_with('-') {
-        ("-", &integer_part[1..])
+    let (sign, digits) = if let Some(stripped) = integer_part.strip_prefix('-') {
+        ("-", stripped)
     } else {
         ("", integer_part)
     };

--- a/src/instance_store/mod.rs
+++ b/src/instance_store/mod.rs
@@ -93,13 +93,13 @@ impl InstanceStore {
     /// Creates all parent directories if they don't exist, then opens the
     /// database and runs the schema migration (idempotent `CREATE TABLE IF NOT EXISTS`).
     pub fn open(db_path: &Path) -> Result<Self, StoreError> {
-        if let Some(parent) = db_path.parent() {
-            if !parent.as_os_str().is_empty() {
-                std::fs::create_dir_all(parent).map_err(|e| StoreError::Io {
-                    path: parent.to_string_lossy().into_owned(),
-                    source: e,
-                })?;
-            }
+        if let Some(parent) = db_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| StoreError::Io {
+                path: parent.to_string_lossy().into_owned(),
+                source: e,
+            })?;
         }
         let conn = Connection::open(db_path)?;
         Self::migrate(&conn)?;

--- a/src/plugin_registry/mod.rs
+++ b/src/plugin_registry/mod.rs
@@ -59,21 +59,16 @@ pub enum RegistryError {
 // ─── Data structures ─────────────────────────────────────────────────────────
 
 /// How a plugin receives its data.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum DataStrategy {
     /// The scheduler polls the source at `refresh_interval_secs`.
+    #[default]
     Polling,
     /// An external system pushes data via `POST /webhook/:id`.
     Webhook,
     /// Data is static; no fetch is performed.
     Static,
-}
-
-impl Default for DataStrategy {
-    fn default() -> Self {
-        DataStrategy::Polling
-    }
 }
 
 /// A single trip evaluation criterion registered by a plugin.

--- a/src/sources/generic.rs
+++ b/src/sources/generic.rs
@@ -23,6 +23,7 @@ pub struct GenericHttpSource {
 }
 
 impl GenericHttpSource {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         name: String,
@@ -120,12 +121,12 @@ impl Source for GenericHttpSource {
             .map_err(|e| SourceError::Parse(format!("invalid JSON: {e}")))?;
 
         // Apply response_root_path if set
-        if let Some(path) = &self.response_root_path {
-            if !path.is_empty() {
-                let extracted = jsonpath_extract(&value, path)
-                    .map_err(|e| SourceError::Parse(format!("JSONPath extraction failed: {e}")))?;
-                return Ok(extracted.clone());
-            }
+        if let Some(path) = &self.response_root_path
+            && !path.is_empty()
+        {
+            let extracted = jsonpath_extract(&value, path)
+                .map_err(|e| SourceError::Parse(format!("JSONPath extraction failed: {e}")))?;
+            return Ok(extracted.clone());
         }
 
         Ok(value)

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -256,7 +256,7 @@ fn insert_commas(digits: &str) -> String {
     let chars: Vec<char> = digits.chars().collect();
     let mut result = String::with_capacity(digits.len() + digits.len() / 3);
     for (i, ch) in chars.iter().enumerate() {
-        if i > 0 && (chars.len() - i) % 3 == 0 {
+        if i > 0 && (chars.len() - i).is_multiple_of(3) {
             result.push(',');
         }
         result.push(*ch);


### PR DESCRIPTION
## Summary

The `rust.yml` CI workflow added in #1 immediately failed because `cargo clippy -- -D warnings` surfaced 13 pre-existing warnings that were never caught without a gate.

This PR fixes all 13 so the Rust CI check goes green.

## Changes

| File | Fix |
|---|---|
| `src/api.rs` | Collapse nested `if let` into a let-chain |
| `src/compositor.rs` | Rename `LayoutVariant::from_str` → `from_name` (avoids confusion with `std::str::FromStr`); collapse nested `if let` |
| `src/config/mod.rs` | Collapse 3 nested `if`/`if let` chains; use `strip_prefix` instead of manual `starts_with` + slice |
| `src/format.rs` | Collapse nested `if let`; use `strip_prefix('-')` instead of `starts_with('-')` + `&s[1..]` |
| `src/instance_store/mod.rs` | Collapse nested `if let` |
| `src/plugin_registry/mod.rs` | Derive `Default` on `DataStrategy` enum instead of manual `impl Default` |
| `src/sources/generic.rs` | `#[allow(clippy::too_many_arguments)]` on the 8-arg constructor; collapse nested `if let` |
| `src/template/mod.rs` | Use `.is_multiple_of(3)` instead of `% 3 == 0` |

All 449 tests still pass.

https://claude.ai/code/session_01XaLNxiix52zEgDpm3xQUFQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaLNxiix52zEgDpm3xQUFQ)_