### PR TITLE
Phase 6a: asset pipeline + LayoutItem::Image + compositor rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -168,6 +169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +210,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -231,7 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
 ]
 
@@ -246,6 +257,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -281,6 +301,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +329,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -439,6 +488,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -703,6 +762,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
+ "jpeg-decoder",
  "num-traits",
  "png",
 ]
@@ -774,6 +834,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "kqueue"
@@ -922,6 +988,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1325,6 +1408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1461,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1567,6 +1667,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,13 @@ description = "Cascades trip-condition rendering pipeline"
 license = "MIT"
 
 [dependencies]
-axum = "0.8"
+axum = { version = "0.8", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
-image = { version = "0.24", default-features = false, features = ["png"] }
+# Phase 6: jpeg + png decoders for user-uploaded asset images.
+image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
 ureq = { version = "2", features = ["json"] }
 thiserror = "1"
 log = "0.4"
@@ -20,6 +21,8 @@ minijinja = { version = "2", features = ["loader"] }
 notify = "6"
 rusqlite = { version = "0.31", features = ["bundled"] }
 rand = "0.10.0"
+# Phase 6: SHA-256 for asset content-addressed dedup.
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/api.rs
+++ b/src/api.rs
@@ -822,6 +822,9 @@ struct ItemPayload {
     /// DataField). `None` → compositor default (`#000`).
     #[serde(default)]
     color: Option<String>,
+    /// Foreign key into AssetStore for `LayoutItem::Image` (Phase 6).
+    #[serde(default)]
+    asset_id: Option<String>,
     #[serde(default)]
     parent_id: Option<String>,
     #[serde(default)]
@@ -917,6 +920,18 @@ impl ItemPayload {
                 plugin_instance_id: self.plugin_instance_id,
                 label: self.label,
                 background: self.background,
+                parent_id: self.parent_id,
+            }),
+            "image" => Ok(LayoutItem::Image {
+                id: self.id,
+                z_index: self.z_index,
+                x: self.x,
+                y: self.y,
+                width: self.width,
+                height: self.height,
+                asset_id: self.asset_id.ok_or_else(|| {
+                    "image item requires asset_id".to_string()
+                })?,
                 parent_id: self.parent_id,
             }),
             other => Err(format!("unknown item_type '{other}'")),

--- a/src/api.rs
+++ b/src/api.rs
@@ -33,7 +33,7 @@ use std::sync::{Arc, RwLock};
 
 use axum::{
     body::{Body, Bytes},
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Multipart, Path, State},
     http::{header, HeaderMap, Response, StatusCode},
     response::IntoResponse,
     routing::{delete, get, post, put},
@@ -43,6 +43,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
+    asset_store::{sniff_mime, AssetStore, MAX_ASSET_BYTES},
     compositor::{Compositor, DisplayConfiguration},
     instance_store::InstanceStore,
     layout_store::{LayoutConfig, LayoutItem, LayoutStore},
@@ -61,6 +62,8 @@ pub struct AppState {
     pub layout_store: Arc<LayoutStore>,
     /// SQLite-backed store for user-defined generic HTTP data sources.
     pub source_store: Arc<SourceStore>,
+    /// SQLite-backed store for user-uploaded image assets (Phase 6).
+    pub asset_store: Arc<AssetStore>,
     /// Manages background fetch tasks for generic HTTP data sources.
     pub scheduler: Arc<SourceScheduler>,
     /// In-memory PNG cache: display_id → latest rendered PNG bytes.
@@ -205,6 +208,17 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         // Curated-font bundle — served to both the sidecar (for @font-face)
         // and the admin UI picker from ./fonts/ relative to the server's CWD.
         .route("/fonts/{*path}", get(serve_font))
+        // Phase 6: user-uploaded image assets. Upload requires admin auth and
+        // a per-route body cap; serving is unauthenticated (assets are
+        // referenced from rendered HTML and the admin preview, both of which
+        // need to fetch them like any other static image).
+        .route(
+            "/api/admin/assets",
+            post(admin_upload_asset)
+                .layer(DefaultBodyLimit::max(MAX_ASSET_BYTES + 4096))
+                .get(admin_list_assets),
+        )
+        .route("/api/assets/{id}", get(serve_asset))
         .with_state(state)
 }
 
@@ -242,6 +256,133 @@ async fn serve_font(
             .into_response(),
         Err(_) => StatusCode::NOT_FOUND.into_response(),
     }
+}
+
+// ─── Asset routes (Phase 6) ──────────────────────────────────────────────────
+
+/// `POST /api/admin/assets` — multipart upload of a single image asset.
+/// Expects a form field named `file` carrying PNG or JPEG bytes (≤1 MiB).
+/// Server-side MIME-sniffs to defeat extension spoofing; dedupes on SHA-256.
+/// Returns `{id, filename, mime, size}` on success.
+async fn admin_upload_asset(
+    headers: HeaderMap,
+    State(app): State<Arc<AppState>>,
+    mut multipart: Multipart,
+) -> Response<Body> {
+    if !is_admin_authorized(&headers, &app.api_key) {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .body(Body::empty())
+            .unwrap();
+    }
+
+    // Walk fields until we find one named "file". We could be stricter (reject
+    // extra fields) but the admin UI sends exactly one and tolerating noise is
+    // friendlier for hand-rolled curl uploads during development.
+    let (filename, bytes) = loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(f)) => f,
+            Ok(None) => {
+                return text_status(
+                    StatusCode::BAD_REQUEST,
+                    "missing 'file' part in multipart body",
+                );
+            }
+            Err(e) => {
+                // axum surfaces a 413 here when the body cap is exceeded; we
+                // forward the status so the admin UI can show a proper error.
+                let status = e.status();
+                return text_status(status, &e.to_string());
+            }
+        };
+        if field.name() == Some("file") {
+            let filename = field
+                .file_name()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| "upload".to_string());
+            let bytes = match field.bytes().await {
+                Ok(b) => b,
+                Err(e) => return text_status(e.status(), &e.to_string()),
+            };
+            break (filename, bytes);
+        }
+    };
+
+    // Defence-in-depth: MAX_ASSET_BYTES is also enforced by DefaultBodyLimit
+    // on the route, but a malformed multipart could in theory slip past.
+    if bytes.len() > MAX_ASSET_BYTES {
+        return text_status(StatusCode::PAYLOAD_TOO_LARGE, "asset exceeds 1 MiB cap");
+    }
+
+    let mime = match sniff_mime(&bytes) {
+        Some(m) => m,
+        None => {
+            return text_status(
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "only PNG and JPEG uploads are accepted",
+            );
+        }
+    };
+
+    match app.asset_store.insert_or_get(&bytes, &filename, mime) {
+        Ok(id) => {
+            let body = serde_json::json!({
+                "id": id,
+                "filename": filename,
+                "mime": mime,
+                "size": bytes.len(),
+            });
+            (StatusCode::OK, Json(body)).into_response()
+        }
+        Err(e) => text_status(StatusCode::BAD_REQUEST, &e.to_string()),
+    }
+}
+
+/// `GET /api/admin/assets` — list uploaded assets (id, filename, mime, size).
+/// Admin auth required; the byte content is fetched separately via
+/// `GET /api/assets/{id}`.
+async fn admin_list_assets(
+    headers: HeaderMap,
+    State(app): State<Arc<AppState>>,
+) -> Response<Body> {
+    if !is_admin_authorized(&headers, &app.api_key) {
+        return Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .body(Body::empty())
+            .unwrap();
+    }
+    match app.asset_store.list() {
+        Ok(items) => Json(items).into_response(),
+        Err(e) => text_status(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+/// `GET /api/assets/{id}` — serve an uploaded asset's raw bytes with the
+/// stored MIME as `Content-Type`. Unauthenticated by design (rendered HTML
+/// and the admin preview both fetch via this route, similar to `/fonts`).
+async fn serve_asset(
+    Path(id): Path<String>,
+    State(app): State<Arc<AppState>>,
+) -> Response<Body> {
+    match app.asset_store.get(&id) {
+        Ok(Some(asset)) => Response::builder()
+            .header(header::CONTENT_TYPE, asset.mime)
+            // Long cache: assets are content-addressed by id; if the bytes
+            // change, the id changes too, so we never need to invalidate.
+            .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+            .body(Body::from(asset.bytes))
+            .unwrap(),
+        Ok(None) => text_status(StatusCode::NOT_FOUND, "asset not found"),
+        Err(e) => text_status(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    }
+}
+
+fn text_status(status: StatusCode, msg: &str) -> Response<Body> {
+    Response::builder()
+        .status(status)
+        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+        .body(Body::from(msg.to_string()))
+        .unwrap()
 }
 
 // ─── Handlers ────────────────────────────────────────────────────────────────
@@ -2137,6 +2278,7 @@ mod tests {
     /// Uses a temporary SQLite database seeded with the 5 well-known instances
     /// and an empty templates directory (status doesn't render any templates).
     fn make_test_state() -> Arc<AppState> {
+        use crate::asset_store::AssetStore;
         use crate::config::{Config, DisplayConfig, LocationConfig, SourceIntervals, StorageConfig};
         use crate::layout_store::LayoutStore;
         use crate::source_store::SourceStore;
@@ -2149,6 +2291,7 @@ mod tests {
         let instance_store = Arc::new(InstanceStore::open(&db_path).unwrap());
         let layout_store = Arc::new(LayoutStore::open(&db_path).unwrap());
         let source_store = Arc::new(SourceStore::open(&db_path).unwrap());
+        let asset_store = Arc::new(AssetStore::open(&db_path).unwrap());
         let config = Config {
             display: DisplayConfig { width: 800, height: 480 },
             location: LocationConfig {
@@ -2195,6 +2338,7 @@ mod tests {
             instance_store,
             layout_store,
             source_store,
+            asset_store,
             scheduler,
             image_cache: Arc::new(RwLock::new(HashMap::new())),
             plugin_registry: PluginRegistry::new(),
@@ -2333,6 +2477,7 @@ mod tests {
 
     /// Returns `(AppState, TempDir)` — caller must keep `TempDir` alive for writes.
     fn make_writable_test_state() -> (Arc<AppState>, tempfile::TempDir) {
+        use crate::asset_store::AssetStore;
         use crate::config::{Config, DisplayConfig, LocationConfig, SourceIntervals, StorageConfig};
         use crate::layout_store::LayoutStore;
         use crate::source_store::SourceStore;
@@ -2345,6 +2490,7 @@ mod tests {
         let instance_store = Arc::new(InstanceStore::open(&db_path).unwrap());
         let layout_store = Arc::new(LayoutStore::open(&db_path).unwrap());
         let source_store = Arc::new(SourceStore::open(&db_path).unwrap());
+        let asset_store = Arc::new(AssetStore::open(&db_path).unwrap());
         let config = Config {
             display: DisplayConfig { width: 800, height: 480 },
             location: LocationConfig { latitude: 48.4, longitude: -122.3, name: "Test".to_string() },
@@ -2382,6 +2528,7 @@ mod tests {
             instance_store,
             layout_store,
             source_store,
+            asset_store,
             scheduler,
             image_cache: Arc::new(RwLock::new(HashMap::new())),
             plugin_registry: PluginRegistry::new(),

--- a/src/asset_store/mod.rs
+++ b/src/asset_store/mod.rs
@@ -131,11 +131,16 @@ impl AssetStore {
             )));
         }
         let sha256 = hex_sha256(bytes);
+        // Content-addressed id. Avoids the same-millisecond collision a
+        // timestamp-based id would have under concurrent distinct uploads,
+        // and makes `Cache-Control: immutable` on the serve route truly
+        // correct: identical bytes always resolve to the same id.
+        let id = format!("asset-{}", &sha256[..16]);
 
         let conn = self.conn.lock().unwrap();
-        // Dedup: if the hash already exists, return that id. Same bytes = same
-        // asset, regardless of filename — saves disk and avoids confusing the
-        // user with two ids for one image.
+        // Dedup: if the same bytes were already stored, return that row's
+        // id (which equals what we'd compute anyway, so this is really an
+        // existence check). The first-upload's filename wins.
         if let Some(existing_id) = conn
             .query_row(
                 "SELECT id FROM assets WHERE sha256 = ?1",
@@ -147,13 +152,6 @@ impl AssetStore {
             return Ok(existing_id);
         }
 
-        let id = format!(
-            "asset-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_millis()
-        );
         let now = unix_now();
         conn.execute(
             "INSERT INTO assets (id, filename, mime, bytes, sha256, created_at)

--- a/src/asset_store/mod.rs
+++ b/src/asset_store/mod.rs
@@ -1,0 +1,347 @@
+//! Asset store — SQLite-backed persistence for user-uploaded image assets.
+//!
+//! Phase 6 introduces user-supplied images (logos, decorations, backgrounds)
+//! that drop onto layouts via `LayoutItem::Image`. Storage is content-addressed
+//! by SHA-256 so re-uploading identical bytes returns the existing id rather
+//! than duplicating the BLOB.
+//!
+//! # Schema
+//!
+//! ```sql
+//! CREATE TABLE IF NOT EXISTS assets (
+//!     id          TEXT PRIMARY KEY,        -- "asset-<unix_millis>" — user-facing
+//!     filename    TEXT NOT NULL,           -- original upload filename, for UI display
+//!     mime        TEXT NOT NULL,           -- "image/png" | "image/jpeg"
+//!     bytes       BLOB NOT NULL,           -- raw file bytes; capped at 1 MiB upstream
+//!     sha256      TEXT NOT NULL UNIQUE,    -- hex-encoded; UNIQUE drives dedup
+//!     created_at  INTEGER NOT NULL         -- unix seconds
+//! );
+//! ```
+
+use std::{path::Path, sync::Mutex};
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Hard cap on a single asset's stored bytes. Enforced both at the upload
+/// route (axum `DefaultBodyLimit`) and here as a defence-in-depth check.
+pub const MAX_ASSET_BYTES: usize = 1_048_576; // 1 MiB
+
+/// MIME types accepted by the asset pipeline. SVG is deliberately excluded for
+/// v1 — the compositor decodes assets via `image::load_from_memory`, which is
+/// raster-only. SVG support is a v1.x deferral.
+pub const ALLOWED_MIMES: &[&str] = &["image/png", "image/jpeg"];
+
+#[derive(Debug, Error)]
+pub enum AssetStoreError {
+    #[error("database error: {0}")]
+    Db(#[from] rusqlite::Error),
+    #[error("I/O error creating directory '{path}': {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("validation error: {0}")]
+    Validation(String),
+}
+
+/// A stored asset — bytes + metadata.
+#[derive(Debug, Clone)]
+pub struct Asset {
+    pub id: String,
+    pub filename: String,
+    pub mime: String,
+    pub bytes: Vec<u8>,
+    pub sha256: String,
+    pub created_at: i64,
+}
+
+/// Lightweight summary used by the admin asset library list (omits `bytes`).
+#[derive(Debug, Clone, Serialize)]
+pub struct AssetSummary {
+    pub id: String,
+    pub filename: String,
+    pub mime: String,
+    pub size: i64,
+    pub created_at: i64,
+}
+
+/// SQLite-backed asset store. Thread-safe via an internal `Mutex<Connection>`;
+/// wrap in `Arc` for shared use.
+pub struct AssetStore {
+    conn: Mutex<Connection>,
+}
+
+impl AssetStore {
+    /// Open or create the SQLite database at `db_path` and run migrations.
+    /// Safe to open against the same file as the other stores.
+    pub fn open(db_path: &Path) -> Result<Self, AssetStoreError> {
+        if let Some(parent) = db_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent).map_err(|e| AssetStoreError::Io {
+                path: parent.to_string_lossy().into_owned(),
+                source: e,
+            })?;
+        }
+        let conn = Connection::open(db_path)?;
+        Self::migrate(&conn)?;
+        Ok(Self { conn: Mutex::new(conn) })
+    }
+
+    fn migrate(conn: &Connection) -> Result<(), AssetStoreError> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS assets (
+                id          TEXT PRIMARY KEY,
+                filename    TEXT NOT NULL,
+                mime        TEXT NOT NULL,
+                bytes       BLOB NOT NULL,
+                sha256      TEXT NOT NULL UNIQUE,
+                created_at  INTEGER NOT NULL
+            );",
+        )?;
+        Ok(())
+    }
+
+    /// Insert a new asset, or — if the bytes already exist (matched by SHA-256)
+    /// — return the existing asset's id without writing again. Validates size,
+    /// MIME, and refuses empty bytes.
+    pub fn insert_or_get(
+        &self,
+        bytes: &[u8],
+        filename: &str,
+        mime: &str,
+    ) -> Result<String, AssetStoreError> {
+        if bytes.is_empty() {
+            return Err(AssetStoreError::Validation("empty asset bytes".into()));
+        }
+        if bytes.len() > MAX_ASSET_BYTES {
+            return Err(AssetStoreError::Validation(format!(
+                "asset exceeds {} byte cap (got {})",
+                MAX_ASSET_BYTES,
+                bytes.len()
+            )));
+        }
+        if !ALLOWED_MIMES.contains(&mime) {
+            return Err(AssetStoreError::Validation(format!(
+                "unsupported MIME '{mime}'; allowed: {ALLOWED_MIMES:?}"
+            )));
+        }
+        let sha256 = hex_sha256(bytes);
+
+        let conn = self.conn.lock().unwrap();
+        // Dedup: if the hash already exists, return that id. Same bytes = same
+        // asset, regardless of filename — saves disk and avoids confusing the
+        // user with two ids for one image.
+        if let Some(existing_id) = conn
+            .query_row(
+                "SELECT id FROM assets WHERE sha256 = ?1",
+                params![sha256],
+                |r| r.get::<_, String>(0),
+            )
+            .optional()?
+        {
+            return Ok(existing_id);
+        }
+
+        let id = format!(
+            "asset-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        );
+        let now = unix_now();
+        conn.execute(
+            "INSERT INTO assets (id, filename, mime, bytes, sha256, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![id, filename, mime, bytes, sha256, now],
+        )?;
+        Ok(id)
+    }
+
+    /// Fetch an asset by id. Returns `Ok(None)` if not found.
+    pub fn get(&self, id: &str) -> Result<Option<Asset>, AssetStoreError> {
+        let conn = self.conn.lock().unwrap();
+        let row = conn
+            .query_row(
+                "SELECT id, filename, mime, bytes, sha256, created_at
+                 FROM assets WHERE id = ?1",
+                params![id],
+                |r| {
+                    Ok(Asset {
+                        id: r.get(0)?,
+                        filename: r.get(1)?,
+                        mime: r.get(2)?,
+                        bytes: r.get(3)?,
+                        sha256: r.get(4)?,
+                        created_at: r.get(5)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
+    /// List all assets as summaries (no bytes). Most-recent first.
+    pub fn list(&self) -> Result<Vec<AssetSummary>, AssetStoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, filename, mime, length(bytes), created_at
+             FROM assets ORDER BY created_at DESC, id DESC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(AssetSummary {
+                    id: r.get(0)?,
+                    filename: r.get(1)?,
+                    mime: r.get(2)?,
+                    size: r.get(3)?,
+                    created_at: r.get(4)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+}
+
+/// MIME-sniff a small byte buffer. Returns one of the `ALLOWED_MIMES` strings
+/// or `None` if the magic bytes don't match a supported format. Hand-rolled to
+/// avoid pulling in an extra crate for two signatures.
+pub fn sniff_mime(bytes: &[u8]) -> Option<&'static str> {
+    // PNG: 89 50 4E 47 0D 0A 1A 0A
+    if bytes.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+        return Some("image/png");
+    }
+    // JPEG: FF D8 FF (covers JFIF, EXIF, raw — common variants)
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        return Some("image/jpeg");
+    }
+    None
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut s = String::with_capacity(64);
+    for b in digest {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_store() -> (tempfile::TempDir, AssetStore) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let store = AssetStore::open(&dir.path().join("test.db")).unwrap();
+        (dir, store)
+    }
+
+    /// Minimal valid 1×1 PNG — 67 bytes. Used so tests never touch the
+    /// filesystem and the file stays self-contained.
+    fn one_pixel_png() -> Vec<u8> {
+        vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // signature
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR len + tag
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1×1
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, // depth/color/etc + crc
+            0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, // IDAT len + tag
+            0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01,
+            0x0D, 0x0A, 0x2D, 0xB4, // IDAT data + crc
+            0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82, // IEND
+        ]
+    }
+
+    #[test]
+    fn sniff_recognizes_png_and_jpeg() {
+        assert_eq!(sniff_mime(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]), Some("image/png"));
+        assert_eq!(sniff_mime(&[0xFF, 0xD8, 0xFF, 0xE0]), Some("image/jpeg"));
+        assert_eq!(sniff_mime(b"GIF89a"), None);
+        assert_eq!(sniff_mime(&[]), None);
+    }
+
+    #[test]
+    fn insert_and_get_roundtrip() {
+        let (_d, store) = tmp_store();
+        let png = one_pixel_png();
+        let id = store.insert_or_get(&png, "logo.png", "image/png").unwrap();
+        let got = store.get(&id).unwrap().unwrap();
+        assert_eq!(got.filename, "logo.png");
+        assert_eq!(got.mime, "image/png");
+        assert_eq!(got.bytes, png);
+        assert_eq!(got.sha256.len(), 64);
+    }
+
+    #[test]
+    fn dedup_returns_same_id_for_same_bytes() {
+        let (_d, store) = tmp_store();
+        let png = one_pixel_png();
+        let id1 = store.insert_or_get(&png, "a.png", "image/png").unwrap();
+        // Different filename — should still dedupe on content hash.
+        let id2 = store.insert_or_get(&png, "b.png", "image/png").unwrap();
+        assert_eq!(id1, id2);
+        // And the stored filename keeps the *first* upload's name (ids are
+        // immutable; renames would require a separate API).
+        assert_eq!(store.get(&id1).unwrap().unwrap().filename, "a.png");
+    }
+
+    #[test]
+    fn rejects_empty_oversized_and_unknown_mime() {
+        let (_d, store) = tmp_store();
+        // empty
+        assert!(matches!(
+            store.insert_or_get(&[], "x.png", "image/png"),
+            Err(AssetStoreError::Validation(_))
+        ));
+        // oversized
+        let big = vec![0u8; MAX_ASSET_BYTES + 1];
+        assert!(matches!(
+            store.insert_or_get(&big, "big.png", "image/png"),
+            Err(AssetStoreError::Validation(_))
+        ));
+        // unknown MIME
+        let png = one_pixel_png();
+        assert!(matches!(
+            store.insert_or_get(&png, "x.svg", "image/svg+xml"),
+            Err(AssetStoreError::Validation(_))
+        ));
+    }
+
+    #[test]
+    fn get_unknown_id_returns_none() {
+        let (_d, store) = tmp_store();
+        assert!(store.get("asset-doesnotexist").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_returns_summaries_sorted_newest_first() {
+        let (_d, store) = tmp_store();
+        let a = store.insert_or_get(&one_pixel_png(), "first.png", "image/png").unwrap();
+        // Tweak one byte to get a distinct hash without growing the test.
+        let mut other = one_pixel_png();
+        other[20] ^= 0x01;
+        // Sleep 1s to guarantee distinct created_at — the table sorts by
+        // created_at DESC and the unix-second granularity could otherwise tie.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let b = store.insert_or_get(&other, "second.png", "image/png").unwrap();
+
+        let list = store.list().unwrap();
+        assert_eq!(list.len(), 2);
+        // Newest first.
+        assert_eq!(list[0].id, b);
+        assert_eq!(list[1].id, a);
+        assert!(list[0].size > 0);
+    }
+}

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -26,6 +26,7 @@ use image::{GrayImage, ImageEncoder};
 use thiserror::Error;
 use tokio::task;
 
+use crate::asset_store::AssetStore;
 use crate::config::DisplayConfigEntry;
 use crate::fonts::FontsManifest;
 use crate::format::apply_format;
@@ -239,6 +240,11 @@ pub struct Compositor {
     sidecar_url: String,
     /// Curated fonts + URL base the sidecar should hit to fetch them.
     fonts: FontsWrap,
+    /// Phase 6: source for `LayoutItem::Image` bytes. Optional so legacy
+    /// callers (and a handful of unit tests that don't exercise images) can
+    /// still construct a compositor without an asset store; image items
+    /// render as no-ops with a warning when this is `None`.
+    asset_store: Option<Arc<AssetStore>>,
 }
 
 impl Compositor {
@@ -267,7 +273,16 @@ impl Compositor {
                 manifest: fonts_manifest,
                 base_url: font_base_url.into(),
             },
+            asset_store: None,
         }
+    }
+
+    /// Builder-style attachment for the asset store. Production wiring
+    /// (`main.rs`) calls this so `LayoutItem::Image` items can resolve their
+    /// `asset_id` to bytes; tests that don't render images can skip it.
+    pub fn with_asset_store(mut self, asset_store: Arc<AssetStore>) -> Self {
+        self.asset_store = Some(asset_store);
+        self
     }
 
     /// Render all items in `config` and composite them into a final 800×480 PNG.
@@ -291,6 +306,10 @@ impl Compositor {
 
         for item in &config.items {
             let maybe_task = match item {
+                // Phase 6: image rendering is synchronous (decode + alpha blit
+                // on the compositor thread), so it never spawns a sidecar
+                // task. The actual paint happens in the post-join loop below.
+                LayoutItem::Image { .. } => None,
                 LayoutItem::PluginSlot {
                     plugin_instance_id,
                     layout_variant,
@@ -458,7 +477,41 @@ impl Compositor {
             png_results.push(handle.await??);
         }
 
-        composite_to_png(&config.items, &task_for_item, &png_results)
+        // Phase 6: pre-fetch bytes for every Image item so the synchronous
+        // compositor doesn't have to touch SQLite. Errors (missing asset,
+        // invalid bytes) are logged but never fail the whole render — a
+        // missing asset becomes a blank rectangle, which is far less
+        // surprising than a 500 from /image.png.
+        let mut image_bytes: HashMap<String, Vec<u8>> = HashMap::new();
+        if let Some(store) = &self.asset_store {
+            for item in &config.items {
+                if let LayoutItem::Image { asset_id, .. } = item {
+                    if image_bytes.contains_key(asset_id) {
+                        continue;
+                    }
+                    let store = Arc::clone(store);
+                    let aid = asset_id.clone();
+                    let result = task::spawn_blocking(move || store.get(&aid)).await?;
+                    match result {
+                        Ok(Some(asset)) => {
+                            image_bytes.insert(asset_id.clone(), asset.bytes);
+                        }
+                        Ok(None) => {
+                            log::warn!(
+                                "compose: asset '{asset_id}' referenced by Image not found",
+                            );
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "compose: failed to load asset '{asset_id}': {e}",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        composite_to_png(&config.items, &task_for_item, &png_results, &image_bytes)
     }
 }
 
@@ -847,6 +900,7 @@ fn composite_to_png(
     items: &[LayoutItem],
     task_for_item: &[Option<usize>],
     png_results: &[Vec<u8>],
+    image_bytes: &HashMap<String, Vec<u8>>,
 ) -> Result<Vec<u8>, CompositorError> {
     // Allocate white frame.
     let pixels = vec![255u8; (FRAME_WIDTH * FRAME_HEIGHT) as usize];
@@ -932,6 +986,29 @@ fn composite_to_png(
                     );
                 }
             }
+            LayoutItem::Image { x, y, width, height, asset_id, .. } => {
+                if let Some(bytes) = image_bytes.get(asset_id) {
+                    // Failure (corrupted bytes, unsupported subformat) downgrades
+                    // to a logged warning + skipped paint — a broken asset
+                    // shouldn't take down the whole composite render.
+                    if let Err(e) = blit_asset_image(
+                        &mut frame,
+                        bytes,
+                        (*x).max(0) as u32,
+                        (*y).max(0) as u32,
+                        (*width).max(0) as u32,
+                        (*height).max(0) as u32,
+                        asset_id,
+                    ) {
+                        log::warn!(
+                            "compose: skipping image '{asset_id}': {e}",
+                        );
+                    }
+                }
+                // Else: bytes were absent (missing asset or no asset_store
+                // wired); already logged in compose(). Render as no-op so the
+                // user sees an empty box where the image was.
+            }
         }
     }
 
@@ -951,6 +1028,67 @@ fn composite_to_png(
 
 /// Decode `png_bytes` and copy up to `(width × height)` pixels onto `frame`
 /// at offset `(x, y)`.
+/// Decode PNG/JPEG bytes, resize to (`width`, `height`), and alpha-composite
+/// onto the grayscale frame. Used by `LayoutItem::Image`. Distinct from
+/// `blit_png` because:
+/// - Sidecar PNGs are already at the slot size (no resize).
+/// - Sidecar PNGs are L8 (text on white), so no alpha blending is needed.
+/// - Asset images are user-supplied at arbitrary dimensions and may carry
+///   transparency we want to honour.
+///
+/// **Stretch fit.** The image scales to exactly the box size — aspect ratio
+/// is the user's responsibility (set the box aspect to match). Documented as
+/// such; if users complain we'd add a `fit_mode` field rather than guess.
+fn blit_asset_image(
+    frame: &mut GrayImage,
+    bytes: &[u8],
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+    asset_id: &str,
+) -> Result<(), CompositorError> {
+    if width == 0 || height == 0 {
+        return Ok(());
+    }
+    let src = image::load_from_memory(bytes).map_err(|_| CompositorError::InvalidPng {
+        slot: format!("image:{asset_id}"),
+    })?;
+    // LumaA preserves transparency for compositing; a fully opaque JPEG
+    // ends up with alpha=255 everywhere, which is exactly what we want.
+    let resized = image::imageops::resize(
+        &src.to_luma_alpha8(),
+        width,
+        height,
+        image::imageops::FilterType::Triangle,
+    );
+
+    for py in 0..height {
+        for px in 0..width {
+            let dst_x = x + px;
+            let dst_y = y + py;
+            if dst_x >= FRAME_WIDTH || dst_y >= FRAME_HEIGHT {
+                continue;
+            }
+            let p = resized.get_pixel(px, py);
+            let src_l = p.0[0] as u16;
+            let alpha = p.0[1] as u16;
+            if alpha == 0 {
+                continue; // fully transparent — leave dst untouched
+            }
+            if alpha == 255 {
+                frame.put_pixel(dst_x, dst_y, image::Luma([src_l as u8]));
+            } else {
+                let dst_l = frame.get_pixel(dst_x, dst_y).0[0] as u16;
+                // Standard alpha over: out = src*a + dst*(1-a), in [0,255].
+                let out = (src_l * alpha + dst_l * (255 - alpha)) / 255;
+                frame.put_pixel(dst_x, dst_y, image::Luma([out as u8]));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn blit_png(
     frame: &mut GrayImage,
     png_bytes: &[u8],
@@ -1235,7 +1373,7 @@ mod tests {
     #[test]
     fn composite_to_png_white_frame() {
         // No items → pure white 800×480 frame.
-        let png = composite_to_png(&[], &[], &[]).unwrap();
+        let png = composite_to_png(&[], &[], &[], &std::collections::HashMap::new()).unwrap();
         assert!(png.starts_with(b"\x89PNG"));
         let img = image::load_from_memory(&png).unwrap();
         assert_eq!(img.width(), FRAME_WIDTH);
@@ -1270,7 +1408,7 @@ mod tests {
         let task_for_item = vec![Some(0usize)];
         let png_results = vec![slot_png];
 
-        let png = composite_to_png(&[item], &task_for_item, &png_results).unwrap();
+        let png = composite_to_png(&[item], &task_for_item, &png_results, &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         assert_eq!(frame.get_pixel(100, 50).0[0], 0);
@@ -1291,7 +1429,7 @@ mod tests {
         };
 
         let task_for_item = vec![None];
-        let png = composite_to_png(&[item], &task_for_item, &[]).unwrap();
+        let png = composite_to_png(&[item], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Row 200 and 201 should be all black.
@@ -1335,7 +1473,7 @@ mod tests {
         let task_for_item = vec![Some(0usize)];
         let png_results = vec![text_png];
 
-        let png = composite_to_png(&[item], &task_for_item, &png_results).unwrap();
+        let png = composite_to_png(&[item], &task_for_item, &png_results, &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Inside the text area should be grey.
@@ -1391,7 +1529,7 @@ mod tests {
         let task_for_item = vec![Some(0usize), Some(1usize)];
         let png_results = vec![white_png, black_png];
 
-        let png = composite_to_png(&items, &task_for_item, &png_results).unwrap();
+        let png = composite_to_png(&items, &task_for_item, &png_results, &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Black (z=1) overwrote white (z=0).
@@ -1412,7 +1550,7 @@ mod tests {
             parent_id: None,
         };
         let task_for_item = vec![None];
-        let png = composite_to_png(&[item], &task_for_item, &[]).unwrap();
+        let png = composite_to_png(&[item], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Border pixels are black.
@@ -1447,7 +1585,7 @@ mod tests {
             parent_id: None,
         };
         let task_for_item = vec![None];
-        let png = composite_to_png(&[item], &task_for_item, &[]).unwrap();
+        let png = composite_to_png(&[item], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Frame is still pure white.
@@ -1478,7 +1616,7 @@ mod tests {
             parent_id: Some("g".to_string()),
         };
         let task_for_item = vec![None, None];
-        let png = composite_to_png(&[group, child], &task_for_item, &[]).unwrap();
+        let png = composite_to_png(&[group, child], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Inside the child rectangle — should be black (child painted on top).
@@ -1487,6 +1625,75 @@ mod tests {
         assert_eq!(frame.get_pixel(140, 140).0[0], 255, "group interior should be white");
         // Group border should still be visible.
         assert_eq!(frame.get_pixel(100, 100).0[0], 0, "group border top-left");
+    }
+
+    /// A 4×4 black PNG bytes generated via the `image` crate, kept inline so
+    /// tests don't ship a binary fixture. Compositor uses `to_luma_alpha8()`
+    /// internally so any encoding the `image` crate accepts is fine here.
+    fn black_4x4_png() -> Vec<u8> {
+        // 4×4 fully-black opaque image. RGBA so we can assert alpha pathway.
+        let img = image::RgbaImage::from_fn(4, 4, |_, _| image::Rgba([0, 0, 0, 255]));
+        let mut out: Vec<u8> = Vec::new();
+        let encoder = image::codecs::png::PngEncoder::new(&mut out);
+        ImageEncoder::write_image(
+            encoder,
+            img.as_raw(),
+            4,
+            4,
+            image::ColorType::Rgba8,
+        )
+        .unwrap();
+        out
+    }
+
+    /// `LayoutItem::Image` should resize the asset bytes into the item's
+    /// rectangle and stamp pixel values onto the frame. This is the single
+    /// most important sanity check on the Phase 6 render path.
+    #[test]
+    fn composite_to_png_image_renders_at_item_rect() {
+        let png = black_4x4_png();
+        let item = LayoutItem::Image {
+            id: "img1".to_string(),
+            z_index: 0,
+            x: 50, y: 60, width: 30, height: 20,
+            asset_id: "asset-x".to_string(),
+            parent_id: None,
+        };
+        let mut bytes = std::collections::HashMap::new();
+        bytes.insert("asset-x".to_string(), png);
+        let task_for_item = vec![None];
+        let composed = composite_to_png(&[item], &task_for_item, &[], &bytes).unwrap();
+        let frame = image::load_from_memory(&composed).unwrap().to_luma8();
+
+        // Inside the image rectangle: black (the asset is fully black).
+        assert_eq!(frame.get_pixel(60, 70).0[0], 0, "image interior should be black");
+        // Outside the rectangle: untouched white background.
+        assert_eq!(frame.get_pixel(10, 10).0[0], 255, "outside the image stays white");
+        assert_eq!(frame.get_pixel(85, 85).0[0], 255, "outside the image stays white");
+    }
+
+    /// A missing asset (id present in the item but not in the bytes map) must
+    /// not crash the render — it just leaves a blank rectangle.
+    #[test]
+    fn composite_to_png_image_with_missing_asset_is_no_op() {
+        let item = LayoutItem::Image {
+            id: "img1".to_string(),
+            z_index: 0,
+            x: 100, y: 100, width: 50, height: 50,
+            asset_id: "ghost".to_string(),
+            parent_id: None,
+        };
+        let task_for_item = vec![None];
+        let composed = composite_to_png(
+            &[item],
+            &task_for_item,
+            &[],
+            &std::collections::HashMap::new(),
+        )
+        .unwrap();
+        let frame = image::load_from_memory(&composed).unwrap().to_luma8();
+        // Whole frame is the white background — no panic, no paint.
+        assert_eq!(frame.get_pixel(125, 125).0[0], 255);
     }
 
     #[test]

--- a/src/layout_store/mod.rs
+++ b/src/layout_store/mod.rs
@@ -170,6 +170,22 @@ pub enum LayoutItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
     },
+    /// A user-uploaded image asset placed at a fixed rectangle. The asset's
+    /// raw bytes live in the [AssetStore](crate::asset_store::AssetStore);
+    /// `asset_id` is the foreign key. Compositor stretches the decoded image
+    /// to (`width`, `height`); aspect-preserving fit is a deferred follow-up.
+    Image {
+        id: String,
+        z_index: i32,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        /// References [Asset::id](crate::asset_store::Asset::id).
+        asset_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_id: Option<String>,
+    },
     /// A container item whose children's `parent_id` points at its `id`.
     ///
     /// Groups have geometry (a visual frame) and an optional background, but
@@ -205,6 +221,7 @@ impl LayoutItem {
             Self::StaticDateTime { id, .. } => id,
             Self::StaticDivider { id, .. } => id,
             Self::DataField { id, .. } => id,
+            Self::Image { id, .. } => id,
             Self::Group { id, .. } => id,
         }
     }
@@ -216,6 +233,7 @@ impl LayoutItem {
             Self::StaticDateTime { z_index, .. } => *z_index,
             Self::StaticDivider { z_index, .. } => *z_index,
             Self::DataField { z_index, .. } => *z_index,
+            Self::Image { z_index, .. } => *z_index,
             Self::Group { z_index, .. } => *z_index,
         }
     }
@@ -228,6 +246,7 @@ impl LayoutItem {
             Self::StaticDateTime { parent_id, .. } => parent_id.as_deref(),
             Self::StaticDivider { parent_id, .. } => parent_id.as_deref(),
             Self::DataField { parent_id, .. } => parent_id.as_deref(),
+            Self::Image { parent_id, .. } => parent_id.as_deref(),
             Self::Group { parent_id, .. } => parent_id.as_deref(),
         }
     }
@@ -314,6 +333,8 @@ impl LayoutStore {
             ("background", "TEXT"),
             // Phase 5: per-item foreground color (CSS hex, e.g. "#ff0000").
             ("color", "TEXT"),
+            // Phase 6: foreign key into assets.id for LayoutItem::Image.
+            ("asset_id", "TEXT"),
         ];
         for (col, typ) in &columns {
             let sql = format!("ALTER TABLE layout_items ADD COLUMN {col} {typ}");
@@ -378,7 +399,7 @@ impl LayoutStore {
                     plugin_instance_id, layout_variant, text_content, font_size, orientation,
                     field_mapping_id, format_string, label,
                     bold, italic, underline, font_family,
-                    parent_id, background, color
+                    parent_id, background, color, asset_id
              FROM layout_items
              WHERE layout_id = ?1
              ORDER BY z_index, id",
@@ -408,6 +429,7 @@ impl LayoutStore {
                 row.get::<_, Option<String>>(19)?,
                 row.get::<_, Option<String>>(20)?,
                 row.get::<_, Option<String>>(21)?,
+                row.get::<_, Option<String>>(22)?,
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -417,7 +439,7 @@ impl LayoutStore {
              plugin_instance_id, layout_variant, text_content, font_size, orientation,
              field_mapping_id, format_string, label,
              bold, italic, underline, font_family,
-             parent_id, background, color) in rows
+             parent_id, background, color, asset_id) in rows
         {
             let bold = bold.map(|v| v != 0);
             let italic = italic.map(|v| v != 0);
@@ -497,6 +519,19 @@ impl LayoutStore {
                     underline,
                     font_family,
                     color,
+                    parent_id,
+                },
+                "image" => LayoutItem::Image {
+                    id: item_id,
+                    z_index,
+                    x,
+                    y,
+                    width,
+                    height,
+                    // Should always be present for image rows; default to ""
+                    // for forward-compat / damaged rows so the read path
+                    // doesn't panic.
+                    asset_id: asset_id.unwrap_or_default(),
                     parent_id,
                 },
                 "group" => LayoutItem::Group {
@@ -633,6 +668,20 @@ impl LayoutStore {
                             font_family,
                             color,
                             parent_id,
+                        ],
+                    )?;
+                }
+                LayoutItem::Image {
+                    id, z_index, x, y, width, height, asset_id, parent_id,
+                } => {
+                    tx.execute(
+                        "INSERT INTO layout_items
+                         (id, layout_id, item_type, z_index, x, y, width, height,
+                          asset_id, parent_id)
+                         VALUES (?1, ?2, 'image', ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                        params![
+                            id, layout.id, z_index, x, y, width, height,
+                            asset_id, parent_id,
                         ],
                     )?;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod asset_store;
 pub mod compositor;
 pub mod config;
 pub mod domain;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use cascades::{
     api::{AppState, SourceScheduler, build_router},
+    asset_store::AssetStore,
     build_sources,
     config::{load_config, load_display_layouts, load_or_create_secrets},
     compositor::Compositor,
@@ -58,6 +59,11 @@ async fn main() {
     // Open source store for generic HTTP data sources.
     let source_store = Arc::new(
         SourceStore::open(store_path).expect("failed to open source store"),
+    );
+
+    // Open asset store for user-uploaded image assets (Phase 6).
+    let asset_store = Arc::new(
+        AssetStore::open(store_path).expect("failed to open asset store"),
     );
 
     // Plugin registry — load definitions from config/plugins.d/.
@@ -160,6 +166,7 @@ async fn main() {
         instance_store,
         layout_store,
         source_store,
+        asset_store,
         scheduler,
         image_cache: Arc::new(RwLock::new(HashMap::new())),
         plugin_registry,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,14 +96,17 @@ async fn main() {
     let server_port = config.server.as_ref().map(|s| s.port).unwrap_or(8080);
     let font_base_url = format!("http://localhost:{server_port}");
 
-    let compositor = Arc::new(Compositor::new(
-        Arc::clone(&template_engine),
-        Arc::clone(&instance_store),
-        Arc::clone(&layout_store),
-        sidecar_url.clone(),
-        Arc::clone(&fonts_manifest),
-        font_base_url,
-    ));
+    let compositor = Arc::new(
+        Compositor::new(
+            Arc::clone(&template_engine),
+            Arc::clone(&instance_store),
+            Arc::clone(&layout_store),
+            sidecar_url.clone(),
+            Arc::clone(&fonts_manifest),
+            font_base_url,
+        )
+        .with_asset_store(Arc::clone(&asset_store)),
+    );
 
     let refresh_rate_secs = config
         .server

--- a/tests/phase5_style_tests.rs
+++ b/tests/phase5_style_tests.rs
@@ -47,6 +47,8 @@ fn make_test_router(base_dir: &Path) -> axum::Router {
         .unwrap();
     let source_store =
         Arc::new(cascades::source_store::SourceStore::open(&db_path).unwrap());
+    let asset_store =
+        Arc::new(cascades::asset_store::AssetStore::open(&db_path).unwrap());
     let scheduler = Arc::new(cascades::api::SourceScheduler::new(Arc::clone(&source_store)));
 
     let state = Arc::new(AppState {
@@ -54,6 +56,7 @@ fn make_test_router(base_dir: &Path) -> axum::Router {
         instance_store,
         layout_store,
         source_store,
+        asset_store,
         scheduler,
         image_cache: Arc::new(RwLock::new(HashMap::<String, Vec<u8>>::new())),
         plugin_registry: cascades::plugin_registry::PluginRegistry::new(),

--- a/tests/phase6_assets_tests.rs
+++ b/tests/phase6_assets_tests.rs
@@ -1,0 +1,281 @@
+//! Phase 6 — asset pipeline + LayoutItem::Image tests.
+//!
+//! Each test maps to a red-green step in the Phase 6 implementation
+//! (see `docs/plugin-customization-design.md`).
+
+use axum::body::Body;
+use axum::http::Request;
+use std::path::Path;
+use std::sync::{Arc, RwLock};
+use tower::ServiceExt;
+
+/// Minimal valid 1×1 PNG (67 bytes). Self-contained so tests don't touch
+/// the filesystem.
+fn one_pixel_png() -> Vec<u8> {
+    vec![
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89,
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54,
+        0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01,
+        0x0D, 0x0A, 0x2D, 0xB4,
+        0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ]
+}
+
+fn make_test_router(base_dir: &Path) -> axum::Router {
+    use cascades::{
+        api::{AppState, build_router},
+        compositor::Compositor,
+        instance_store::InstanceStore,
+        layout_store::{LayoutConfig, LayoutStore},
+        template::TemplateEngine,
+    };
+    use std::collections::HashMap;
+
+    let db_path = base_dir.join("test.db");
+    let templates_dir = base_dir.join("templates");
+    std::fs::create_dir_all(&templates_dir).unwrap();
+
+    let instance_store = Arc::new(InstanceStore::open(&db_path).unwrap());
+    let layout_store = Arc::new(LayoutStore::open(&db_path).unwrap());
+    let template_engine = Arc::new(TemplateEngine::new(&templates_dir).unwrap());
+    let compositor = Arc::new(Compositor::new(
+        Arc::clone(&template_engine),
+        Arc::clone(&instance_store),
+        Arc::clone(&layout_store),
+        "http://localhost:9999",
+        Arc::new(cascades::fonts::FontsManifest::empty()),
+        "http://localhost:0".to_string(),
+    ));
+    layout_store
+        .upsert_layout(&LayoutConfig {
+            id: "default".to_string(),
+            name: "default".to_string(),
+            items: vec![],
+            updated_at: 0,
+        })
+        .unwrap();
+    let source_store =
+        Arc::new(cascades::source_store::SourceStore::open(&db_path).unwrap());
+    let asset_store =
+        Arc::new(cascades::asset_store::AssetStore::open(&db_path).unwrap());
+    let scheduler = Arc::new(cascades::api::SourceScheduler::new(Arc::clone(&source_store)));
+
+    let state = Arc::new(AppState {
+        compositor,
+        instance_store,
+        layout_store,
+        source_store,
+        asset_store,
+        scheduler,
+        image_cache: Arc::new(RwLock::new(HashMap::<String, Vec<u8>>::new())),
+        plugin_registry: cascades::plugin_registry::PluginRegistry::new(),
+        api_key: "test-bearer-key".to_string(),
+        refresh_rate_secs: 42,
+        started_at: std::time::Instant::now(),
+        sidecar_url: "http://localhost:3001".to_string(),
+    });
+    build_router(state)
+}
+
+/// Build a multipart/form-data body containing a single `file` field. The
+/// admin upload route only cares about that field name; everything else is
+/// boilerplate to satisfy the multer parser. Inlined so tests don't depend
+/// on a multipart-builder crate.
+fn multipart_body(filename: &str, content_type: &str, bytes: &[u8]) -> (String, Vec<u8>) {
+    let boundary = "----CASCADESBOUNDARY";
+    let mut body: Vec<u8> = Vec::new();
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"{filename}\"\r\n",
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(format!("Content-Type: {content_type}\r\n\r\n").as_bytes());
+    body.extend_from_slice(bytes);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+    let header = format!("multipart/form-data; boundary={boundary}");
+    (header, body)
+}
+
+#[tokio::test]
+async fn upload_route_accepts_png_and_returns_id() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = make_test_router(dir.path());
+    let png = one_pixel_png();
+    let (ct, body) = multipart_body("logo.png", "image/png", &png);
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/admin/assets")
+        .header("x-api-key", "test-bearer-key")
+        .header("content-type", ct)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = http_body_util::BodyExt::collect(resp.into_body())
+        .await
+        .unwrap()
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["id"].as_str().unwrap().starts_with("asset-"));
+    assert_eq!(json["mime"], "image/png");
+    assert_eq!(json["size"], png.len() as u64);
+}
+
+#[tokio::test]
+async fn upload_route_requires_admin_auth() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = make_test_router(dir.path());
+    let (ct, body) = multipart_body("x.png", "image/png", &one_pixel_png());
+    // No x-api-key header.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/admin/assets")
+        .header("content-type", ct)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn upload_route_rejects_non_image_bytes_with_415() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = make_test_router(dir.path());
+    // The upload claims image/png in its multipart Content-Type, but the
+    // bytes are plainly not a PNG. Server-side MIME sniff must reject.
+    let bytes = b"not actually a png at all";
+    let (ct, body) = multipart_body("fake.png", "image/png", bytes);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/admin/assets")
+        .header("x-api-key", "test-bearer-key")
+        .header("content-type", ct)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 415);
+}
+
+#[tokio::test]
+async fn upload_route_dedupes_identical_bytes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = make_test_router(dir.path());
+    let png = one_pixel_png();
+
+    async fn upload_once(app: &axum::Router, png: &[u8], filename: &str) -> String {
+        let (ct, body) = multipart_body(filename, "image/png", png);
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/admin/assets")
+            .header("x-api-key", "test-bearer-key")
+            .header("content-type", ct)
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+        let body = http_body_util::BodyExt::collect(resp.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        json["id"].as_str().unwrap().to_string()
+    }
+
+    let id_a = upload_once(&app, &png, "first.png").await;
+    let id_b = upload_once(&app, &png, "second.png").await;
+    assert_eq!(id_a, id_b, "identical bytes must dedupe to one id");
+}
+
+#[tokio::test]
+async fn serve_route_returns_bytes_with_correct_content_type() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = make_test_router(dir.path());
+    let png = one_pixel_png();
+    let (ct, body) = multipart_body("u.png", "image/png", &png);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/admin/assets")
+        .header("x-api-key", "test-bearer-key")
+        .header("content-type", ct)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let body = http_body_util::BodyExt::collect(resp.into_body())
+        .await
+        .unwrap()
+        .to_bytes();
+    let id = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Now fetch — no auth header; serving is public by design.
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/api/assets/{id}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap().to_str().unwrap(),
+        "image/png",
+    );
+    let body = http_body_util::BodyExt::collect(resp.into_body())
+        .await
+        .unwrap()
+        .to_bytes();
+    assert_eq!(body.as_ref(), png.as_slice());
+}
+
+#[tokio::test]
+async fn serve_route_returns_404_for_unknown_id() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = make_test_router(dir.path());
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/assets/asset-doesnotexist")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn list_route_returns_uploaded_assets() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let app = make_test_router(dir.path());
+    let (ct, body) = multipart_body("a.png", "image/png", &one_pixel_png());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/admin/assets")
+        .header("x-api-key", "test-bearer-key")
+        .header("content-type", ct)
+        .body(Body::from(body))
+        .unwrap();
+    app.clone().oneshot(req).await.unwrap();
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/admin/assets")
+        .header("x-api-key", "test-bearer-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = http_body_util::BodyExt::collect(resp.into_body())
+        .await
+        .unwrap()
+        .to_bytes();
+    let arr: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["filename"], "a.png");
+    assert_eq!(arr[0]["mime"], "image/png");
+}

--- a/tests/phase6_assets_tests.rs
+++ b/tests/phase6_assets_tests.rs
@@ -248,6 +248,48 @@ async fn serve_route_returns_404_for_unknown_id() {
     assert_eq!(resp.status(), 404);
 }
 
+/// `LayoutItem::Image` must roundtrip through the SQLite layout store —
+/// proves the new `asset_id` column was added correctly and that the read
+/// path picks up the variant. Mirrors Phase 5a's `layout_item_color_…` test.
+#[test]
+fn layout_item_image_roundtrips_through_store() {
+    use cascades::layout_store::{LayoutConfig, LayoutItem, LayoutStore};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+    let original = LayoutItem::Image {
+        id: "img-42".to_string(),
+        z_index: 3,
+        x: 50,
+        y: 60,
+        width: 120,
+        height: 80,
+        asset_id: "asset-abc123".to_string(),
+        parent_id: Some("group-1".to_string()),
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L1".to_string(),
+            name: "L1".to_string(),
+            items: vec![original.clone()],
+            updated_at: 0,
+        })
+        .unwrap();
+
+    let loaded = store.get_layout("L1").unwrap().unwrap();
+    assert_eq!(loaded.items.len(), 1);
+    match &loaded.items[0] {
+        LayoutItem::Image { id, asset_id, x, y, width, height, parent_id, z_index } => {
+            assert_eq!(id, "img-42");
+            assert_eq!(asset_id, "asset-abc123");
+            assert_eq!((*x, *y, *width, *height), (50, 60, 120, 80));
+            assert_eq!(*z_index, 3);
+            assert_eq!(parent_id.as_deref(), Some("group-1"));
+        }
+        other => panic!("expected Image, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn list_route_returns_uploaded_assets() {
     let dir = tempfile::TempDir::new().unwrap();

--- a/tests/server_acceptance_tests.rs
+++ b/tests/server_acceptance_tests.rs
@@ -1030,6 +1030,9 @@ fn make_api_app(
     let source_store = Arc::new(
         cascades::source_store::SourceStore::open(&db_path).expect("open source store"),
     );
+    let asset_store = Arc::new(
+        cascades::asset_store::AssetStore::open(&db_path).expect("open asset store"),
+    );
     let scheduler = Arc::new(cascades::api::SourceScheduler::new(Arc::clone(&source_store)));
 
     let state = Arc::new(AppState {
@@ -1037,6 +1040,7 @@ fn make_api_app(
         instance_store,
         layout_store,
         source_store,
+        asset_store,
         scheduler,
         image_cache,
         plugin_registry: cascades::plugin_registry::PluginRegistry::new(),
@@ -1139,6 +1143,9 @@ async fn webhook_invalidates_image_cache_for_affected_display() {
     let source_store = Arc::new(
         cascades::source_store::SourceStore::open(&db_path).unwrap(),
     );
+    let asset_store = Arc::new(
+        cascades::asset_store::AssetStore::open(&db_path).unwrap(),
+    );
     let scheduler = Arc::new(cascades::api::SourceScheduler::new(Arc::clone(&source_store)));
 
     let state = Arc::new(cascades::api::AppState {
@@ -1146,6 +1153,7 @@ async fn webhook_invalidates_image_cache_for_affected_display() {
         instance_store,
         layout_store,
         source_store,
+        asset_store,
         scheduler,
         image_cache: Arc::clone(&image_cache),
         plugin_registry: cascades::plugin_registry::PluginRegistry::new(),


### PR DESCRIPTION
## Summary

Backend half of **Phase 6** from `docs/plugin-customization-design.md`. Adds the user-uploaded-image pipeline end-to-end: SQLite-backed AssetStore, multipart upload + content-addressed serve routes, the `LayoutItem::Image` variant, and compositor rendering with alpha-aware blits onto the e-ink frame.

This PR ships **without admin-UI surface** — same a/b split as Phase 5. Phase 6b (next PR) lands the asset library panel + drag-onto-canvas in `templates/admin.html`. Until 6b lands, asset uploads work via `curl` and Image items work via direct API; the user-facing affordance follows.

## Commits

- `a025d5e` — AssetStore + upload/serve/list HTTP routes
- `15250cd` — `LayoutItem::Image` + compositor rendering
- `00b921f` — content-address asset ids by sha256 prefix (advisor-flagged: avoids same-millisecond collision)

## Design decisions called out

- **SVG deferred to v1.x.** The design doc mentions PNG/SVG, but `image::load_from_memory` is raster-only and the doc also requires "no sidecar needed for static images." Adding `resvg` for SVG would drag a 2 MB dep tree for a v1 use case that logos+icons don't actually need. **PNG + JPEG only** for v1; uploads of other formats return 415.
- **Stretch fit, not aspect-preserving.** The compositor scales the asset to exactly the item's box; users set the box aspect to control the image aspect. If users complain we'd add a `fit_mode: stretch | contain` field rather than guess defaults.
- **`/api/assets/{id}` is public.** Same precedent as `/fonts/{*path}`: rendered HTML and the admin preview both fetch via this route, so requiring auth would break sidecar renders. Asset URLs are guessable like font URLs.
- **1 MiB upload cap.** Enforced both by axum's per-route `DefaultBodyLimit` (returns 413) and by AssetStore validation (defence-in-depth). The cap is per-asset, not aggregate.
- **PNG + JPEG only via server-side magic-byte sniff.** Defeats extension spoofing without a sniffing crate; `infer` was unnecessary for two signatures.
- **Content-addressed ids (`asset-{sha256[..16]}`).** Avoids same-millisecond collisions on concurrent distinct uploads, makes the `Cache-Control: immutable` header semantically correct, and makes dedup automatic.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — **474/474** passing (was 458; +6 asset_store unit + +8 phase6 route/roundtrip + +2 compositor render)
- [x] **End-to-end smoke test** (advisor-recommended; main.rs wiring isn't covered by `cargo test`):
  - `curl POST /api/admin/assets` → 200 with `{id, filename, mime, size}`
  - `curl GET /api/assets/{id}` → 200, `Content-Type: image/png`, byte-for-byte identical
  - Re-upload identical bytes → returns same id
  - Non-PNG/JPEG bytes → 415
  - Missing auth → 401
  - Unknown id → 404
- [ ] Reviewer: confirm SVG-deferred decision is acceptable; if not, follow-up PR adds `resvg` or sidecar-rasterise path
- [ ] Reviewer: confirm `Cache-Control: immutable` semantics are okay (no DELETE route in this PR — would land alongside admin UI deletion in 6b)

## What 6b adds (next PR)

- Asset library panel in `templates/admin.html` (lists assets, upload form)
- Drag-onto-canvas creates a `LayoutItem::Image` bound to the dropped asset
- Property inspector for Image items (asset swap, x/y/w/h)
- A 6b smoke test asserting the new HTML markers exist (same pattern as Phase 5b's `admin_html_contains_phase5b_markers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)