### PR TITLE
Phase 7a: visible_when conditions + LayoutItem::DataIcon backend

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -829,10 +829,23 @@ struct ItemPayload {
     parent_id: Option<String>,
     #[serde(default)]
     background: Option<String>,
+    /// Phase 7: optional conditional-rendering clause (`{path, op, value}`).
+    /// Skipped on Group items.
+    #[serde(default)]
+    visible_when: Option<crate::visible_when::VisibleWhen>,
+    /// Phase 7: value → asset_id map for `LayoutItem::DataIcon`. Required
+    /// for that variant; ignored on others.
+    #[serde(default)]
+    icon_map: Option<std::collections::HashMap<String, String>>,
 }
 
 impl ItemPayload {
     fn into_layout_item(self) -> Result<LayoutItem, String> {
+        // Phase 7: per design-doc decision, Group items don't carry visible_when.
+        // We accept (and ignore) the field on Group payloads rather than reject
+        // them — admin UI sends a uniform shape, and rejecting would force the
+        // client to special-case Group serialization.
+        let visible_when = self.visible_when;
         match self.item_type.as_str() {
             "plugin_slot" => Ok(LayoutItem::PluginSlot {
                 id: self.id,
@@ -844,6 +857,7 @@ impl ItemPayload {
                 plugin_instance_id: self.plugin_instance_id.unwrap_or_default(),
                 layout_variant: self.layout_variant.unwrap_or_else(|| "full".to_string()),
                 parent_id: self.parent_id,
+                visible_when,
             }),
             "static_text" => Ok(LayoutItem::StaticText {
                 id: self.id,
@@ -861,6 +875,7 @@ impl ItemPayload {
                 font_family: self.font_family,
                 color: self.color,
                 parent_id: self.parent_id,
+                visible_when,
             }),
             "static_datetime" => Ok(LayoutItem::StaticDateTime {
                 id: self.id,
@@ -878,6 +893,7 @@ impl ItemPayload {
                 font_family: self.font_family,
                 color: self.color,
                 parent_id: self.parent_id,
+                visible_when,
             }),
             "static_divider" => Ok(LayoutItem::StaticDivider {
                 id: self.id,
@@ -888,6 +904,7 @@ impl ItemPayload {
                 height: self.height,
                 orientation: self.orientation,
                 parent_id: self.parent_id,
+                visible_when,
             }),
             "data_field" => Ok(LayoutItem::DataField {
                 id: self.id,
@@ -909,6 +926,7 @@ impl ItemPayload {
                 font_family: self.font_family,
                 color: self.color,
                 parent_id: self.parent_id,
+                visible_when,
             }),
             "group" => Ok(LayoutItem::Group {
                 id: self.id,
@@ -933,6 +951,24 @@ impl ItemPayload {
                     "image item requires asset_id".to_string()
                 })?,
                 parent_id: self.parent_id,
+                visible_when,
+            }),
+            "data_icon" => Ok(LayoutItem::DataIcon {
+                id: self.id,
+                z_index: self.z_index,
+                x: self.x,
+                y: self.y,
+                width: self.width,
+                height: self.height,
+                field_mapping_id: self.field_mapping_id.ok_or_else(|| {
+                    "data_icon item requires field_mapping_id".to_string()
+                })?,
+                // Default empty map = always-blank rendering until the user
+                // populates entries via the inspector. Same forgiving default
+                // as missing-asset on Image.
+                icon_map: self.icon_map.unwrap_or_default(),
+                parent_id: self.parent_id,
+                visible_when,
             }),
             other => Err(format!("unknown item_type '{other}'")),
         }
@@ -2947,6 +2983,7 @@ mod tests {
                 z_index: 0, x: 0, y: 240, width: 800, height: 2,
                 orientation: None,
                 parent_id: None,
+                visible_when: None,
             }],
             updated_at: 0,
         }).unwrap();
@@ -2997,6 +3034,7 @@ mod tests {
                 font_family: None,
                 color: None,
                 parent_id: None,
+                visible_when: None,
             }],
             updated_at: 0,
         }).unwrap();

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -163,6 +163,7 @@ impl DisplayConfiguration {
                     plugin_instance_id: s.plugin.clone(),
                     layout_variant: s.variant.clone(),
                     parent_id: None,
+                    visible_when: None,
                 })
             })
             .collect::<Result<Vec<_>, CompositorError>>()?;
@@ -299,17 +300,47 @@ impl Compositor {
         config: &DisplayConfiguration,
         render_mode: &str,
     ) -> Result<Vec<u8>, CompositorError> {
+        // Phase 7: build the eval snapshot once per render — a single JSON
+        // object keyed by plugin_instance_id containing each instance's
+        // cached_data. visible_when paths like `$.weather.precip_chance_pct`
+        // resolve against this. Built up-front so it's both consistent across
+        // all items and reusable for DataIcon resolution below.
+        let eval_snapshot = build_eval_snapshot(&self.instance_store).await;
+
+        // Phase 7: filter items whose visible_when clause evaluates false.
+        // visible[i] mirrors config.items; we track in parallel rather than
+        // shrinking the items vec so we can use the existing item-index
+        // relationship for task_for_item / png_results without remapping.
+        let visible: Vec<bool> = config
+            .items
+            .iter()
+            .map(|it| {
+                it.visible_when()
+                    .map(|vw| vw.evaluate(&eval_snapshot))
+                    .unwrap_or(true)
+            })
+            .collect();
+
         // For each item, we either spawn an async render task or handle it inline.
         // task_for_item[i] = Some(handle_index) if item i has an async task, else None.
         let mut task_for_item: Vec<Option<usize>> = Vec::with_capacity(config.items.len());
         let mut handles: Vec<task::JoinHandle<Result<Vec<u8>, CompositorError>>> = Vec::new();
 
-        for item in &config.items {
+        for (idx, item) in config.items.iter().enumerate() {
+            // Phase 7: hidden items don't render. Push None so indices line up
+            // for the post-join loop, but skip the work.
+            if !visible[idx] {
+                task_for_item.push(None);
+                continue;
+            }
             let maybe_task = match item {
                 // Phase 6: image rendering is synchronous (decode + alpha blit
                 // on the compositor thread), so it never spawns a sidecar
                 // task. The actual paint happens in the post-join loop below.
                 LayoutItem::Image { .. } => None,
+                // Phase 7: DataIcon also renders synchronously after the join
+                // (resolves value → asset_id → bytes from the asset store).
+                LayoutItem::DataIcon { .. } => None,
                 LayoutItem::PluginSlot {
                     plugin_instance_id,
                     layout_variant,
@@ -482,36 +513,149 @@ impl Compositor {
         // invalid bytes) are logged but never fail the whole render — a
         // missing asset becomes a blank rectangle, which is far less
         // surprising than a 500 from /image.png.
+        // Phase 6: pre-fetch Image bytes (keyed by asset_id, dedup-friendly).
+        // Phase 7: pre-resolve DataIcon items — extract value via field
+        // mapping, look up in icon_map, fetch bytes — and stash in
+        // data_icon_bytes keyed by item id (each DataIcon may resolve to a
+        // different asset based on data, so item id is the natural key).
         let mut image_bytes: HashMap<String, Vec<u8>> = HashMap::new();
+        let mut data_icon_bytes: HashMap<String, Vec<u8>> = HashMap::new();
         if let Some(store) = &self.asset_store {
-            for item in &config.items {
-                if let LayoutItem::Image { asset_id, .. } = item {
-                    if image_bytes.contains_key(asset_id) {
-                        continue;
-                    }
-                    let store = Arc::clone(store);
-                    let aid = asset_id.clone();
-                    let result = task::spawn_blocking(move || store.get(&aid)).await?;
-                    match result {
-                        Ok(Some(asset)) => {
-                            image_bytes.insert(asset_id.clone(), asset.bytes);
+            for (idx, item) in config.items.iter().enumerate() {
+                if !visible[idx] {
+                    continue;
+                }
+                match item {
+                    LayoutItem::Image { asset_id, .. } => {
+                        if image_bytes.contains_key(asset_id) {
+                            continue;
                         }
-                        Ok(None) => {
-                            log::warn!(
-                                "compose: asset '{asset_id}' referenced by Image not found",
-                            );
-                        }
-                        Err(e) => {
-                            log::warn!(
-                                "compose: failed to load asset '{asset_id}': {e}",
-                            );
+                        if let Some(bytes) = fetch_asset_bytes(store, asset_id).await? {
+                            image_bytes.insert(asset_id.clone(), bytes);
                         }
                     }
+                    LayoutItem::DataIcon { id, field_mapping_id, icon_map, .. } => {
+                        // Resolve value via field mapping; missing → no icon.
+                        let extracted = resolve_data_icon_value(
+                            &self.layout_store,
+                            &eval_snapshot,
+                            field_mapping_id,
+                        )
+                        .await;
+                        let Some(value_str) = extracted else { continue };
+                        let Some(asset_id) = icon_map.get(&value_str) else {
+                            log::warn!(
+                                "compose: DataIcon '{id}' value '{value_str}' not in icon_map; rendering blank",
+                            );
+                            continue;
+                        };
+                        if let Some(bytes) = fetch_asset_bytes(store, asset_id).await? {
+                            data_icon_bytes.insert(id.clone(), bytes);
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
 
-        composite_to_png(&config.items, &task_for_item, &png_results, &image_bytes)
+        composite_to_png(
+            &config.items,
+            &visible,
+            &task_for_item,
+            &png_results,
+            &image_bytes,
+            &data_icon_bytes,
+        )
+    }
+}
+
+/// Build a JSON snapshot of all plugin instances' cached data, keyed by
+/// instance id. Used by [`VisibleWhen::evaluate`] and DataIcon resolution.
+/// Errors fetching individual instances log + omit so a flaky read doesn't
+/// hide every conditional item.
+async fn build_eval_snapshot(instance_store: &Arc<InstanceStore>) -> serde_json::Value {
+    let store = Arc::clone(instance_store);
+    let instances = match task::spawn_blocking(move || store.list_instances()).await {
+        Ok(Ok(list)) => list,
+        Ok(Err(e)) => {
+            log::warn!("compose: failed to list instances for eval snapshot: {e}");
+            return serde_json::Value::Object(serde_json::Map::new());
+        }
+        Err(e) => {
+            log::warn!("compose: instance list task panicked: {e}");
+            return serde_json::Value::Object(serde_json::Map::new());
+        }
+    };
+    let mut root = serde_json::Map::with_capacity(instances.len());
+    for inst in instances {
+        root.insert(
+            inst.id,
+            inst.cached_data.unwrap_or(serde_json::Value::Null),
+        );
+    }
+    serde_json::Value::Object(root)
+}
+
+/// Resolve a DataIcon's `field_mapping_id` against the eval snapshot. Returns
+/// the extracted value as a string (so it matches against `icon_map` keys).
+/// Logs + returns None on any failure path (missing mapping, missing path,
+/// non-string-coercible value); compositor renders a blank rectangle.
+async fn resolve_data_icon_value(
+    layout_store: &Arc<LayoutStore>,
+    snapshot: &serde_json::Value,
+    field_mapping_id: &str,
+) -> Option<String> {
+    let ls = Arc::clone(layout_store);
+    let fmid = field_mapping_id.to_string();
+    let mapping = task::spawn_blocking(move || ls.get_field_mapping(&fmid))
+        .await
+        .ok()?
+        .ok()?;
+    let mapping = mapping?;
+    // Build "$.<source_id>.<rest_of_path>" so the path resolves against the
+    // unified snapshot. `mapping.json_path` is anchored at the instance's own
+    // data; our snapshot is `{instance_id: data}` so we prepend.
+    //
+    // The trim/branch dance handles three input shapes:
+    //   "$.water_level"      → "$.<src>.water_level"   (dot prefix, key root)
+    //   "$.values[0]"        → "$.<src>.values[0]"     (dot prefix, key root)
+    //   "$.[0]"              → "$.<src>[0]"            (dot prefix, array root —
+    //                                                   strip the dot to avoid
+    //                                                   "$.<src>.[0]" which is
+    //                                                   ill-formed)
+    let trimmed = mapping
+        .json_path
+        .strip_prefix('$')
+        .unwrap_or(mapping.json_path.as_str())
+        .trim_start_matches('.');
+    let path = if trimmed.starts_with('[') {
+        format!("$.{}{}", mapping.data_source_id, trimmed)
+    } else {
+        format!("$.{}.{}", mapping.data_source_id, trimmed)
+    };
+    let extracted = crate::jsonpath::jsonpath_extract(snapshot, &path).ok()?;
+    Some(crate::jsonpath::value_to_string(extracted))
+}
+
+/// Helper: fetch asset bytes off-thread, mapping all errors to a logged
+/// `None` so the compositor never fails the whole render on one bad asset.
+async fn fetch_asset_bytes(
+    store: &Arc<AssetStore>,
+    asset_id: &str,
+) -> Result<Option<Vec<u8>>, CompositorError> {
+    let store = Arc::clone(store);
+    let aid = asset_id.to_string();
+    let result = task::spawn_blocking(move || store.get(&aid)).await?;
+    match result {
+        Ok(Some(asset)) => Ok(Some(asset.bytes)),
+        Ok(None) => {
+            log::warn!("compose: asset '{asset_id}' not found");
+            Ok(None)
+        }
+        Err(e) => {
+            log::warn!("compose: failed to load asset '{asset_id}': {e}");
+            Ok(None)
+        }
     }
 }
 
@@ -896,11 +1040,20 @@ async fn call_sidecar(
 ///
 /// Items whose `task_for_item` entry is `None` (skipped during rendering) are
 /// omitted silently.
+/// Helper: treat an empty `visible` vec as "all items visible". Lets unit
+/// tests of `composite_to_png` keep passing `&[]` for tests that don't care
+/// about Phase 7 visibility filtering.
+fn is_visible(visible: &[bool], idx: usize) -> bool {
+    visible.get(idx).copied().unwrap_or(true)
+}
+
 fn composite_to_png(
     items: &[LayoutItem],
+    visible: &[bool],
     task_for_item: &[Option<usize>],
     png_results: &[Vec<u8>],
     image_bytes: &HashMap<String, Vec<u8>>,
+    data_icon_bytes: &HashMap<String, Vec<u8>>,
 ) -> Result<Vec<u8>, CompositorError> {
     // Allocate white frame.
     let pixels = vec![255u8; (FRAME_WIDTH * FRAME_HEIGHT) as usize];
@@ -908,7 +1061,14 @@ fn composite_to_png(
         GrayImage::from_raw(FRAME_WIDTH, FRAME_HEIGHT, pixels)
             .expect("buffer size matches dimensions");
 
-    for (item, maybe_task) in items.iter().zip(task_for_item.iter()) {
+    for (idx, (item, maybe_task)) in items.iter().zip(task_for_item.iter()).enumerate() {
+        // Phase 7: visible_when=false items are omitted entirely. The
+        // visibility vec parallels items (no shrinking) so this index lookup
+        // is cheap and tests that pass an empty `visible` vec still work
+        // (treat as all-visible — see helper below).
+        if !is_visible(visible, idx) {
+            continue;
+        }
         match item {
             LayoutItem::PluginSlot { x, y, width, height, plugin_instance_id, .. } => {
                 if let Some(idx) = maybe_task {
@@ -1008,6 +1168,25 @@ fn composite_to_png(
                 // Else: bytes were absent (missing asset or no asset_store
                 // wired); already logged in compose(). Render as no-op so the
                 // user sees an empty box where the image was.
+            }
+            LayoutItem::DataIcon { id, x, y, width, height, .. } => {
+                // Bytes were resolved upstream in compose() (value lookup →
+                // icon_map → asset bytes). Missing entries here are logged
+                // already; we just paint what's there. Same defensive
+                // contract as Image.
+                if let Some(bytes) = data_icon_bytes.get(id) {
+                    if let Err(e) = blit_asset_image(
+                        &mut frame,
+                        bytes,
+                        (*x).max(0) as u32,
+                        (*y).max(0) as u32,
+                        (*width).max(0) as u32,
+                        (*height).max(0) as u32,
+                        id,
+                    ) {
+                        log::warn!("compose: skipping data_icon '{id}': {e}");
+                    }
+                }
             }
         }
     }
@@ -1295,6 +1474,7 @@ mod tests {
                     plugin_instance_id: "river".to_string(),
                     layout_variant: "quadrant".to_string(),
                     parent_id: None,
+                    visible_when: None,
                 },
                 LayoutItem::StaticText {
                     id: "t0".to_string(),
@@ -1309,6 +1489,7 @@ mod tests {
                     font_family: None,
                     color: None,
                     parent_id: None,
+                    visible_when: None,
                 },
                 LayoutItem::StaticDivider {
                     id: "d0".to_string(),
@@ -1316,6 +1497,7 @@ mod tests {
                     x: 0, y: 240, width: 800, height: 2,
                     orientation: Some("horizontal".to_string()),
                     parent_id: None,
+                    visible_when: None,
                 },
             ],
         };
@@ -1340,6 +1522,7 @@ mod tests {
                     plugin_instance_id: "river".to_string(),
                     layout_variant: "bogus_variant".to_string(),
                     parent_id: None,
+                    visible_when: None,
                 },
                 LayoutItem::StaticDivider {
                     id: "d0".to_string(),
@@ -1347,6 +1530,7 @@ mod tests {
                     x: 0, y: 240, width: 800, height: 2,
                     orientation: None,
                     parent_id: None,
+                    visible_when: None,
                 },
             ],
         };
@@ -1373,7 +1557,7 @@ mod tests {
     #[test]
     fn composite_to_png_white_frame() {
         // No items → pure white 800×480 frame.
-        let png = composite_to_png(&[], &[], &[], &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&[], &[], &[], &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         assert!(png.starts_with(b"\x89PNG"));
         let img = image::load_from_memory(&png).unwrap();
         assert_eq!(img.width(), FRAME_WIDTH);
@@ -1403,12 +1587,13 @@ mod tests {
             plugin_instance_id: "test".to_string(),
             layout_variant: "quadrant".to_string(),
             parent_id: None,
+            visible_when: None,
         };
 
         let task_for_item = vec![Some(0usize)];
         let png_results = vec![slot_png];
 
-        let png = composite_to_png(&[item], &task_for_item, &png_results, &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&[item], &[], &task_for_item, &png_results, &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         assert_eq!(frame.get_pixel(100, 50).0[0], 0);
@@ -1426,10 +1611,11 @@ mod tests {
             width: 800, height: 2,
             orientation: Some("horizontal".to_string()),
             parent_id: None,
+            visible_when: None,
         };
 
         let task_for_item = vec![None];
-        let png = composite_to_png(&[item], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&[item], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Row 200 and 201 should be all black.
@@ -1468,12 +1654,13 @@ mod tests {
             font_family: None,
             color: None,
             parent_id: None,
+            visible_when: None,
         };
 
         let task_for_item = vec![Some(0usize)];
         let png_results = vec![text_png];
 
-        let png = composite_to_png(&[item], &task_for_item, &png_results, &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&[item], &[], &task_for_item, &png_results, &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Inside the text area should be grey.
@@ -1517,6 +1704,7 @@ mod tests {
                 plugin_instance_id: "white".to_string(),
                 layout_variant: "quadrant".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
             LayoutItem::PluginSlot {
                 id: "s1".to_string(), z_index: 1,
@@ -1524,12 +1712,13 @@ mod tests {
                 plugin_instance_id: "black".to_string(),
                 layout_variant: "quadrant".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
         ];
         let task_for_item = vec![Some(0usize), Some(1usize)];
         let png_results = vec![white_png, black_png];
 
-        let png = composite_to_png(&items, &task_for_item, &png_results, &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&items, &[], &task_for_item, &png_results, &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Black (z=1) overwrote white (z=0).
@@ -1550,7 +1739,7 @@ mod tests {
             parent_id: None,
         };
         let task_for_item = vec![None];
-        let png = composite_to_png(&[item], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&[item], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Border pixels are black.
@@ -1585,7 +1774,7 @@ mod tests {
             parent_id: None,
         };
         let task_for_item = vec![None];
-        let png = composite_to_png(&[item], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&[item], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Frame is still pure white.
@@ -1614,9 +1803,10 @@ mod tests {
             x: 110, y: 120, width: 20, height: 10,
             orientation: None,
             parent_id: Some("g".to_string()),
+            visible_when: None,
         };
         let task_for_item = vec![None, None];
-        let png = composite_to_png(&[group, child], &task_for_item, &[], &std::collections::HashMap::new()).unwrap();
+        let png = composite_to_png(&[group, child], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&png).unwrap().to_luma8();
 
         // Inside the child rectangle — should be black (child painted on top).
@@ -1658,11 +1848,12 @@ mod tests {
             x: 50, y: 60, width: 30, height: 20,
             asset_id: "asset-x".to_string(),
             parent_id: None,
+            visible_when: None,
         };
         let mut bytes = std::collections::HashMap::new();
         bytes.insert("asset-x".to_string(), png);
         let task_for_item = vec![None];
-        let composed = composite_to_png(&[item], &task_for_item, &[], &bytes).unwrap();
+        let composed = composite_to_png(&[item], &[], &task_for_item, &[], &bytes, &std::collections::HashMap::new()).unwrap();
         let frame = image::load_from_memory(&composed).unwrap().to_luma8();
 
         // Inside the image rectangle: black (the asset is fully black).
@@ -1670,6 +1861,96 @@ mod tests {
         // Outside the rectangle: untouched white background.
         assert_eq!(frame.get_pixel(10, 10).0[0], 255, "outside the image stays white");
         assert_eq!(frame.get_pixel(85, 85).0[0], 255, "outside the image stays white");
+    }
+
+    /// Phase 7: items with `visible[i] = false` must not paint. A black
+    /// image item that *would* paint at (50,60)→(80,80) stays unpainted
+    /// when its visibility flag is false.
+    #[test]
+    fn composite_to_png_skips_invisible_items() {
+        let png = black_4x4_png();
+        let item = LayoutItem::Image {
+            id: "img1".to_string(),
+            z_index: 0,
+            x: 50, y: 60, width: 30, height: 20,
+            asset_id: "asset-x".to_string(),
+            parent_id: None,
+            visible_when: None,
+        };
+        let mut bytes = std::collections::HashMap::new();
+        bytes.insert("asset-x".to_string(), png);
+        let task_for_item = vec![None];
+        let composed = composite_to_png(
+            &[item],
+            &[false],
+            &task_for_item,
+            &[],
+            &bytes,
+            &std::collections::HashMap::new(),
+        ).unwrap();
+        let frame = image::load_from_memory(&composed).unwrap().to_luma8();
+        assert_eq!(frame.get_pixel(60, 70).0[0], 255, "hidden image must not paint");
+    }
+
+    /// `composite_to_png` with an empty `visible` slice treats every item as
+    /// visible — needed so legacy callers / tests that don't care about
+    /// Phase 7 don't have to construct a parallel boolean vec.
+    #[test]
+    fn composite_to_png_empty_visible_means_all_visible() {
+        let png = black_4x4_png();
+        let item = LayoutItem::Image {
+            id: "img1".to_string(),
+            z_index: 0,
+            x: 50, y: 60, width: 30, height: 20,
+            asset_id: "asset-x".to_string(),
+            parent_id: None,
+            visible_when: None,
+        };
+        let mut bytes = std::collections::HashMap::new();
+        bytes.insert("asset-x".to_string(), png);
+        let task_for_item = vec![None];
+        let composed = composite_to_png(
+            &[item],
+            &[],
+            &task_for_item,
+            &[],
+            &bytes,
+            &std::collections::HashMap::new(),
+        ).unwrap();
+        let frame = image::load_from_memory(&composed).unwrap().to_luma8();
+        assert_eq!(frame.get_pixel(60, 70).0[0], 0, "empty `visible` should mean fully visible");
+    }
+
+    /// Phase 7: `LayoutItem::DataIcon` shares `blit_asset_image` with
+    /// Image, so the bytes-blit path is well-tested already. This test
+    /// proves the post-join handler correctly looks bytes up by *item id*
+    /// (not asset_id) — the keying detail that's specific to DataIcon.
+    #[test]
+    fn composite_to_png_data_icon_renders_via_item_id_keyed_bytes() {
+        let png = black_4x4_png();
+        let item = LayoutItem::DataIcon {
+            id: "icon-1".to_string(),
+            z_index: 0,
+            x: 100, y: 100, width: 20, height: 20,
+            field_mapping_id: "fm-weather-cond".to_string(),
+            icon_map: std::collections::HashMap::new(),
+            parent_id: None,
+            visible_when: None,
+        };
+        let mut data_icon_bytes = std::collections::HashMap::new();
+        data_icon_bytes.insert("icon-1".to_string(), png);
+        let task_for_item = vec![None];
+        let composed = composite_to_png(
+            &[item],
+            &[],
+            &task_for_item,
+            &[],
+            &std::collections::HashMap::new(),
+            &data_icon_bytes,
+        ).unwrap();
+        let frame = image::load_from_memory(&composed).unwrap().to_luma8();
+        assert_eq!(frame.get_pixel(110, 110).0[0], 0, "data icon must paint at item rect");
+        assert_eq!(frame.get_pixel(50, 50).0[0], 255);
     }
 
     /// A missing asset (id present in the item but not in the bytes map) must
@@ -1682,12 +1963,15 @@ mod tests {
             x: 100, y: 100, width: 50, height: 50,
             asset_id: "ghost".to_string(),
             parent_id: None,
+            visible_when: None,
         };
         let task_for_item = vec![None];
         let composed = composite_to_png(
             &[item],
+            &[],
             &task_for_item,
             &[],
+            &std::collections::HashMap::new(),
             &std::collections::HashMap::new(),
         )
         .unwrap();

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1174,8 +1174,8 @@ fn composite_to_png(
                 // icon_map → asset bytes). Missing entries here are logged
                 // already; we just paint what's there. Same defensive
                 // contract as Image.
-                if let Some(bytes) = data_icon_bytes.get(id) {
-                    if let Err(e) = blit_asset_image(
+                if let Some(bytes) = data_icon_bytes.get(id)
+                    && let Err(e) = blit_asset_image(
                         &mut frame,
                         bytes,
                         (*x).max(0) as u32,
@@ -1183,9 +1183,9 @@ fn composite_to_png(
                         (*width).max(0) as u32,
                         (*height).max(0) as u32,
                         id,
-                    ) {
-                        log::warn!("compose: skipping data_icon '{id}': {e}");
-                    }
+                    )
+                {
+                    log::warn!("compose: skipping data_icon '{id}': {e}");
                 }
             }
         }

--- a/src/layout_store/mod.rs
+++ b/src/layout_store/mod.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::config::DisplayLayoutsConfig;
+use crate::visible_when::VisibleWhen;
 
 // ─── Error type ───────────────────────────────────────────────────────────────
 
@@ -76,6 +77,9 @@ pub enum LayoutItem {
         layout_variant: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
+        /// Phase 7: optional conditional-rendering clause. `None` → always render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        visible_when: Option<VisibleWhen>,
     },
     /// A static text element rendered directly.
     StaticText {
@@ -101,6 +105,9 @@ pub enum LayoutItem {
         color: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
+        /// Phase 7: optional conditional-rendering clause. `None` → always render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        visible_when: Option<VisibleWhen>,
     },
     /// A static date/time element rendered via the sidecar.
     #[serde(rename = "static_datetime")]
@@ -127,6 +134,9 @@ pub enum LayoutItem {
         color: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
+        /// Phase 7: optional conditional-rendering clause. `None` → always render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        visible_when: Option<VisibleWhen>,
     },
     /// A horizontal or vertical divider line.
     StaticDivider {
@@ -139,6 +149,9 @@ pub enum LayoutItem {
         orientation: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
+        /// Phase 7: optional conditional-rendering clause. `None` → always render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        visible_when: Option<VisibleWhen>,
     },
     /// A data field that extracts a value from cached source data via JSONPath.
     DataField {
@@ -169,6 +182,9 @@ pub enum LayoutItem {
         color: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
+        /// Phase 7: optional conditional-rendering clause. `None` → always render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        visible_when: Option<VisibleWhen>,
     },
     /// A user-uploaded image asset placed at a fixed rectangle. The asset's
     /// raw bytes live in the [AssetStore](crate::asset_store::AssetStore);
@@ -185,6 +201,35 @@ pub enum LayoutItem {
         asset_id: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
+        /// Phase 7: optional conditional-rendering clause. `None` → always render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        visible_when: Option<VisibleWhen>,
+    },
+    /// A data-driven icon: extracts a string value from cached source data via
+    /// a [`FieldMapping`], then looks that value up in `icon_map` to choose
+    /// which [`Asset`](crate::asset_store::Asset) to render. Used for
+    /// weather-condition icons, route badges, etc.
+    ///
+    /// Falls back to a blank rectangle if the extracted value isn't a key in
+    /// `icon_map` or the chosen asset is missing — same defensive contract as
+    /// [`LayoutItem::Image`].
+    DataIcon {
+        id: String,
+        z_index: i32,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+        /// References data_source_fields.id (same as DataField).
+        field_mapping_id: String,
+        /// Map of extracted value → asset id. Stored as JSON in
+        /// `icon_map_json` column.
+        icon_map: std::collections::HashMap<String, String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_id: Option<String>,
+        /// Phase 7: optional conditional-rendering clause. `None` → always render.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        visible_when: Option<VisibleWhen>,
     },
     /// A container item whose children's `parent_id` points at its `id`.
     ///
@@ -222,6 +267,7 @@ impl LayoutItem {
             Self::StaticDivider { id, .. } => id,
             Self::DataField { id, .. } => id,
             Self::Image { id, .. } => id,
+            Self::DataIcon { id, .. } => id,
             Self::Group { id, .. } => id,
         }
     }
@@ -234,6 +280,7 @@ impl LayoutItem {
             Self::StaticDivider { z_index, .. } => *z_index,
             Self::DataField { z_index, .. } => *z_index,
             Self::Image { z_index, .. } => *z_index,
+            Self::DataIcon { z_index, .. } => *z_index,
             Self::Group { z_index, .. } => *z_index,
         }
     }
@@ -247,7 +294,24 @@ impl LayoutItem {
             Self::StaticDivider { parent_id, .. } => parent_id.as_deref(),
             Self::DataField { parent_id, .. } => parent_id.as_deref(),
             Self::Image { parent_id, .. } => parent_id.as_deref(),
+            Self::DataIcon { parent_id, .. } => parent_id.as_deref(),
             Self::Group { parent_id, .. } => parent_id.as_deref(),
+        }
+    }
+
+    /// Phase 7: optional conditional-rendering clause. `Group` items don't
+    /// carry one — hiding a group separately from its children is a different
+    /// (cascading) feature deliberately deferred from v1 scope.
+    pub fn visible_when(&self) -> Option<&VisibleWhen> {
+        match self {
+            Self::PluginSlot { visible_when, .. } => visible_when.as_ref(),
+            Self::StaticText { visible_when, .. } => visible_when.as_ref(),
+            Self::StaticDateTime { visible_when, .. } => visible_when.as_ref(),
+            Self::StaticDivider { visible_when, .. } => visible_when.as_ref(),
+            Self::DataField { visible_when, .. } => visible_when.as_ref(),
+            Self::Image { visible_when, .. } => visible_when.as_ref(),
+            Self::DataIcon { visible_when, .. } => visible_when.as_ref(),
+            Self::Group { .. } => None,
         }
     }
 }
@@ -335,6 +399,12 @@ impl LayoutStore {
             ("color", "TEXT"),
             // Phase 6: foreign key into assets.id for LayoutItem::Image.
             ("asset_id", "TEXT"),
+            // Phase 7: serialized VisibleWhen clause (`{path, op, value}`)
+            // or NULL when the item has no condition.
+            ("visible_when_json", "TEXT"),
+            // Phase 7: serialized HashMap<String,String> of value → asset_id
+            // for LayoutItem::DataIcon.
+            ("icon_map_json", "TEXT"),
         ];
         for (col, typ) in &columns {
             let sql = format!("ALTER TABLE layout_items ADD COLUMN {col} {typ}");
@@ -399,7 +469,8 @@ impl LayoutStore {
                     plugin_instance_id, layout_variant, text_content, font_size, orientation,
                     field_mapping_id, format_string, label,
                     bold, italic, underline, font_family,
-                    parent_id, background, color, asset_id
+                    parent_id, background, color, asset_id,
+                    visible_when_json, icon_map_json
              FROM layout_items
              WHERE layout_id = ?1
              ORDER BY z_index, id",
@@ -430,6 +501,8 @@ impl LayoutStore {
                 row.get::<_, Option<String>>(20)?,
                 row.get::<_, Option<String>>(21)?,
                 row.get::<_, Option<String>>(22)?,
+                row.get::<_, Option<String>>(23)?,
+                row.get::<_, Option<String>>(24)?,
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -439,11 +512,23 @@ impl LayoutStore {
              plugin_instance_id, layout_variant, text_content, font_size, orientation,
              field_mapping_id, format_string, label,
              bold, italic, underline, font_family,
-             parent_id, background, color, asset_id) in rows
+             parent_id, background, color, asset_id,
+             visible_when_json, icon_map_json) in rows
         {
             let bold = bold.map(|v| v != 0);
             let italic = italic.map(|v| v != 0);
             let underline = underline.map(|v| v != 0);
+            // Parse visible_when JSON; treat malformed as None and log so the
+            // compositor doesn't panic on a hand-edited DB row. The item then
+            // renders unconditionally (treating "nothing" as "always show").
+            let visible_when: Option<VisibleWhen> = visible_when_json.as_deref()
+                .and_then(|s| match serde_json::from_str::<VisibleWhen>(s) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        log::warn!("layout '{layout_id}' item '{item_id}': bad visible_when_json: {e}");
+                        None
+                    }
+                });
             let item = match item_type.as_str() {
                 "plugin_slot" => LayoutItem::PluginSlot {
                     id: item_id,
@@ -456,6 +541,7 @@ impl LayoutStore {
                     layout_variant: layout_variant
                         .unwrap_or_else(|| "full".to_string()),
                     parent_id,
+                    visible_when,
                 },
                 "static_text" => LayoutItem::StaticText {
                     id: item_id,
@@ -473,6 +559,7 @@ impl LayoutStore {
                     font_family,
                     color: color.clone(),
                     parent_id,
+                    visible_when,
                 },
                 "static_datetime" => LayoutItem::StaticDateTime {
                     id: item_id,
@@ -490,6 +577,7 @@ impl LayoutStore {
                     font_family,
                     color: color.clone(),
                     parent_id,
+                    visible_when,
                 },
                 "static_divider" => LayoutItem::StaticDivider {
                     id: item_id,
@@ -500,6 +588,7 @@ impl LayoutStore {
                     height,
                     orientation,
                     parent_id,
+                    visible_when,
                 },
                 "data_field" => LayoutItem::DataField {
                     id: item_id,
@@ -520,6 +609,7 @@ impl LayoutStore {
                     font_family,
                     color,
                     parent_id,
+                    visible_when,
                 },
                 "image" => LayoutItem::Image {
                     id: item_id,
@@ -533,7 +623,37 @@ impl LayoutStore {
                     // doesn't panic.
                     asset_id: asset_id.unwrap_or_default(),
                     parent_id,
+                    visible_when,
                 },
+                "data_icon" => {
+                    // icon_map_json missing or malformed → empty map (renders
+                    // as blank rect for any value, same defensive contract as
+                    // missing-asset). Logs but doesn't fail the read.
+                    let icon_map = icon_map_json
+                        .as_deref()
+                        .and_then(|s| match serde_json::from_str::<std::collections::HashMap<String, String>>(s) {
+                            Ok(m) => Some(m),
+                            Err(e) => {
+                                log::warn!(
+                                    "layout '{layout_id}' item '{item_id}': bad icon_map_json: {e}",
+                                );
+                                None
+                            }
+                        })
+                        .unwrap_or_default();
+                    LayoutItem::DataIcon {
+                        id: item_id,
+                        z_index,
+                        x,
+                        y,
+                        width,
+                        height,
+                        field_mapping_id: field_mapping_id.unwrap_or_default(),
+                        icon_map,
+                        parent_id,
+                        visible_when,
+                    }
+                }
                 "group" => LayoutItem::Group {
                     id: item_id,
                     z_index,
@@ -573,33 +693,39 @@ impl LayoutStore {
         )?;
 
         for item in &layout.items {
+            // Phase 7: serialize the optional VisibleWhen clause once per
+            // item and reuse on every INSERT branch. None → NULL column.
+            let vw_json: Option<String> = item
+                .visible_when()
+                .map(|v| serde_json::to_string(v).expect("VisibleWhen always serialises"));
             match item {
                 LayoutItem::PluginSlot {
                     id, z_index, x, y, width, height, plugin_instance_id, layout_variant,
-                    parent_id,
+                    parent_id, visible_when: _,
                 } => {
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
-                          plugin_instance_id, layout_variant, parent_id)
-                         VALUES (?1, ?2, 'plugin_slot', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                          plugin_instance_id, layout_variant, parent_id, visible_when_json)
+                         VALUES (?1, ?2, 'plugin_slot', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
                         params![
                             id, layout.id, z_index, x, y, width, height,
-                            plugin_instance_id, layout_variant, parent_id
+                            plugin_instance_id, layout_variant, parent_id, vw_json
                         ],
                     )?;
                 }
                 LayoutItem::StaticText {
                     id, z_index, x, y, width, height, text_content, font_size, orientation,
-                    bold, italic, underline, font_family, color, parent_id,
+                    bold, italic, underline, font_family, color, parent_id, visible_when: _,
                 } => {
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
                           text_content, font_size, orientation,
-                          bold, italic, underline, font_family, color, parent_id)
+                          bold, italic, underline, font_family, color, parent_id,
+                          visible_when_json)
                          VALUES (?1, ?2, 'static_text', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                                 ?11, ?12, ?13, ?14, ?15, ?16)",
+                                 ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                         params![
                             id, layout.id, z_index, x, y, width, height,
                             text_content, font_size, orientation,
@@ -609,20 +735,22 @@ impl LayoutStore {
                             font_family,
                             color,
                             parent_id,
+                            vw_json,
                         ],
                     )?;
                 }
                 LayoutItem::StaticDateTime {
                     id, z_index, x, y, width, height, font_size, format, orientation,
-                    bold, italic, underline, font_family, color, parent_id,
+                    bold, italic, underline, font_family, color, parent_id, visible_when: _,
                 } => {
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
                           text_content, font_size, orientation,
-                          bold, italic, underline, font_family, color, parent_id)
+                          bold, italic, underline, font_family, color, parent_id,
+                          visible_when_json)
                          VALUES (?1, ?2, 'static_datetime', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                                 ?11, ?12, ?13, ?14, ?15, ?16)",
+                                 ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
                         params![
                             id, layout.id, z_index, x, y, width, height,
                             format, font_size, orientation,
@@ -632,33 +760,35 @@ impl LayoutStore {
                             font_family,
                             color,
                             parent_id,
+                            vw_json,
                         ],
                     )?;
                 }
                 LayoutItem::StaticDivider {
-                    id, z_index, x, y, width, height, orientation, parent_id,
+                    id, z_index, x, y, width, height, orientation, parent_id, visible_when: _,
                 } => {
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
-                          orientation, parent_id)
-                         VALUES (?1, ?2, 'static_divider', ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                          orientation, parent_id, visible_when_json)
+                         VALUES (?1, ?2, 'static_divider', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                         params![id, layout.id, z_index, x, y, width, height,
-                                orientation, parent_id],
+                                orientation, parent_id, vw_json],
                     )?;
                 }
                 LayoutItem::DataField {
                     id, z_index, x, y, width, height,
                     field_mapping_id, font_size, format_string, label, orientation,
-                    bold, italic, underline, font_family, color, parent_id,
+                    bold, italic, underline, font_family, color, parent_id, visible_when: _,
                 } => {
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
                           field_mapping_id, font_size, format_string, label, orientation,
-                          bold, italic, underline, font_family, color, parent_id)
+                          bold, italic, underline, font_family, color, parent_id,
+                          visible_when_json)
                          VALUES (?1, ?2, 'data_field', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                                 ?13, ?14, ?15, ?16, ?17, ?18)",
+                                 ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
                         params![
                             id, layout.id, z_index, x, y, width, height,
                             field_mapping_id, font_size, format_string, label, orientation,
@@ -668,20 +798,38 @@ impl LayoutStore {
                             font_family,
                             color,
                             parent_id,
+                            vw_json,
                         ],
                     )?;
                 }
                 LayoutItem::Image {
-                    id, z_index, x, y, width, height, asset_id, parent_id,
+                    id, z_index, x, y, width, height, asset_id, parent_id, visible_when: _,
                 } => {
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
-                          asset_id, parent_id)
-                         VALUES (?1, ?2, 'image', ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                          asset_id, parent_id, visible_when_json)
+                         VALUES (?1, ?2, 'image', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                         params![
                             id, layout.id, z_index, x, y, width, height,
-                            asset_id, parent_id,
+                            asset_id, parent_id, vw_json,
+                        ],
+                    )?;
+                }
+                LayoutItem::DataIcon {
+                    id, z_index, x, y, width, height,
+                    field_mapping_id, icon_map, parent_id, visible_when: _,
+                } => {
+                    let icon_map_json = serde_json::to_string(icon_map)
+                        .expect("HashMap<String,String> always serialises");
+                    tx.execute(
+                        "INSERT INTO layout_items
+                         (id, layout_id, item_type, z_index, x, y, width, height,
+                          field_mapping_id, icon_map_json, parent_id, visible_when_json)
+                         VALUES (?1, ?2, 'data_icon', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                        params![
+                            id, layout.id, z_index, x, y, width, height,
+                            field_mapping_id, icon_map_json, parent_id, vw_json,
                         ],
                     )?;
                 }
@@ -777,6 +925,7 @@ impl LayoutStore {
                     plugin_instance_id: slot.plugin.clone(),
                     layout_variant: slot.variant.clone(),
                     parent_id: None,
+                    visible_when: None,
                 });
             }
             let layout = LayoutConfig {
@@ -1016,6 +1165,7 @@ mod tests {
             plugin_instance_id: plugin.to_string(),
             layout_variant: "full".to_string(),
             parent_id: None,
+            visible_when: None,
         }
     }
 
@@ -1212,6 +1362,7 @@ mod tests {
                     font_family: None,
                     color: None,
                     parent_id: None,
+                    visible_when: None,
                 },
                 LayoutItem::StaticDivider {
                     id: "d0".to_string(),
@@ -1219,6 +1370,7 @@ mod tests {
                     x: 0, y: 240, width: 800, height: 2,
                     orientation: Some("horizontal".to_string()),
                     parent_id: None,
+                    visible_when: None,
                 },
             ],
             updated_at: 0,
@@ -1239,6 +1391,7 @@ mod tests {
             plugin_instance_id: "river".to_string(),
             layout_variant: "full".to_string(),
             parent_id: None,
+            visible_when: None,
         };
         let json = serde_json::to_string(&item).unwrap();
         let decoded: LayoutItem = serde_json::from_str(&json).unwrap();
@@ -1291,6 +1444,7 @@ mod tests {
                     font_family: None,
                     color: None,
                     parent_id: None,
+                    visible_when: None,
                 },
                 LayoutItem::DataField {
                     id: "df1".to_string(),
@@ -1310,6 +1464,7 @@ mod tests {
                     font_family: None,
                     color: None,
                     parent_id: None,
+                    visible_when: None,
                 },
             ],
             updated_at: 0,
@@ -1365,6 +1520,7 @@ mod tests {
             font_family: None,
             color: None,
             parent_id: None,
+            visible_when: None,
         };
         let json = serde_json::to_string(&item).unwrap();
         let decoded: LayoutItem = serde_json::from_str(&json).unwrap();
@@ -1394,6 +1550,7 @@ mod tests {
                     font_family: Some("Georgia, serif".to_string()),
                     color: None,
                     parent_id: None,
+                    visible_when: None,
                 },
                 LayoutItem::DataField {
                     id: "df0".to_string(),
@@ -1410,6 +1567,7 @@ mod tests {
                     font_family: Some("monospace".to_string()),
                     color: None,
                     parent_id: None,
+                    visible_when: None,
                 },
             ],
             updated_at: 0,
@@ -1505,6 +1663,7 @@ mod tests {
                     orientation: None,
                     bold: None, italic: None, underline: None, font_family: None, color: None,
                     parent_id: Some("g0".to_string()),
+                    visible_when: None,
                 },
             ],
             updated_at: 0,
@@ -1575,6 +1734,7 @@ mod tests {
                     x: 0, y: 100, width: 200, height: 2,
                     orientation: Some("horizontal".to_string()),
                     parent_id: Some("g".to_string()),
+                    visible_when: None,
                 },
             ],
             updated_at: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod presentation;
 pub mod source_store;
 pub mod sources;
 pub mod template;
+pub mod visible_when;
 
 use config::Config;
 use sources::Source;

--- a/src/visible_when.rs
+++ b/src/visible_when.rs
@@ -1,0 +1,272 @@
+//! `visible_when` conditional-rendering primitive — Phase 7.
+//!
+//! Layout items may carry a `VisibleWhen { path, op, value }` clause that the
+//! compositor evaluates against a per-render snapshot of plugin-instance data.
+//! Items whose clause resolves to `false` are skipped and never paint.
+//!
+//! # Wire format
+//!
+//! Stored as JSON in the `visible_when_json` column on `layout_items`. The
+//! shape is intentionally simple — a single comparison; no compound
+//! expressions. This is the "firm stop at compound" decision in
+//! `docs/plugin-customization-design.md`.
+//!
+//! ```json
+//! { "path": "$.weather.precip_chance_pct", "op": ">", "value": 0 }
+//! { "path": "$.river.go", "op": "=", "value": true }
+//! { "path": "$.weather.alerts", "op": "exists", "value": null }
+//! ```
+//!
+//! # Defensive evaluation (Phase 7 design decisions)
+//!
+//! - **Missing data → hide.** If `path` doesn't resolve, the clause evaluates
+//!   to false and the item hides. This is the "fail closed" default — better
+//!   to hide an item the user expected to see than to show one they expected
+//!   gone.
+//! - **Type mismatch → hide.** A `>` against a non-numeric value coerces to
+//!   number where possible (string → parse) and otherwise returns false.
+//! - **Malformed clause JSON in the DB → no clause.** The store's read path
+//!   logs a warning and loads the item with `visible_when: None`, so a
+//!   hand-edited corrupt row is treated as "the user never set a clause"
+//!   rather than "the user set an unsatisfiable clause." This is *not* the
+//!   same as the missing-data rule above: missing data on a known clause is
+//!   the user's edge case (data hasn't arrived yet) and they want it hidden;
+//!   a parse error is operational damage outside the admin UI's control and
+//!   defaulting to "always show" matches what they'd see if they hadn't
+//!   touched the row.
+//! - **`exists`** ignores `value`; truthy iff the path resolves to *any* value
+//!   (including `null` — the path being present is what counts).
+//!
+//! Group items deliberately do not carry a `visible_when` field. Hiding a
+//! group separately from its children is a different feature with cascading
+//! semantics; we keep the v1 scope strict.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::jsonpath::jsonpath_extract;
+
+/// One side of a comparison clause. `value` is unused for the `exists`
+/// operator but is still required on the wire so the admin UI's
+/// (`path | op | value`) form keeps a uniform shape.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VisibleWhen {
+    pub path: String,
+    pub op: String,
+    #[serde(default)]
+    pub value: Value,
+}
+
+impl VisibleWhen {
+    /// Evaluate this clause against `snapshot` (typically the per-render
+    /// unified instance map). Returns `true` if the item should render,
+    /// `false` if it should be skipped.
+    ///
+    /// Errors (path missing, type mismatch, unknown op) all collapse to
+    /// `false` per the "fail closed" contract.
+    pub fn evaluate(&self, snapshot: &Value) -> bool {
+        let actual = match jsonpath_extract(snapshot, &self.path) {
+            Ok(v) => v,
+            Err(_) => {
+                // Path missing → hide. (`exists` would have returned false
+                // here anyway, so this branch is correct for both modes.)
+                return false;
+            }
+        };
+
+        match self.op.as_str() {
+            "exists" => true, // path resolved → exists is true
+            "=" => values_equal(actual, &self.value),
+            "!=" => !values_equal(actual, &self.value),
+            ">" => compare_numbers(actual, &self.value).map(|o| o.is_gt()).unwrap_or(false),
+            "<" => compare_numbers(actual, &self.value).map(|o| o.is_lt()).unwrap_or(false),
+            ">=" => compare_numbers(actual, &self.value).map(|o| o.is_ge()).unwrap_or(false),
+            "<=" => compare_numbers(actual, &self.value).map(|o| o.is_le()).unwrap_or(false),
+            _ => false, // unknown op → hide
+        }
+    }
+}
+
+/// Equality with mild coercion: `1` matches `"1"`, `true` matches `true`.
+/// Strings compared as strings; bools as bools; numbers as numbers; nulls
+/// only equal nulls. Cross-type fall back to string equality after
+/// `value_to_string`-style flattening.
+fn values_equal(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::String(x), Value::String(y)) => x == y,
+        (Value::Bool(x), Value::Bool(y)) => x == y,
+        (Value::Number(x), Value::Number(y)) => {
+            // Compare as f64 — JSON numbers are loosely typed.
+            x.as_f64() == y.as_f64()
+        }
+        (Value::Null, Value::Null) => true,
+        // Cross-type: stringify both and compare. Lets the wire format stay
+        // user-friendly ("0" vs 0 still match) without a strict-types
+        // schema. Empirical decision matching the rest of this codebase's
+        // forgiving JSON handling.
+        _ => stringify(a) == stringify(b),
+    }
+}
+
+fn stringify(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        _ => v.to_string(),
+    }
+}
+
+fn compare_numbers(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
+    let af = to_f64(a)?;
+    let bf = to_f64(b)?;
+    af.partial_cmp(&bf)
+}
+
+fn to_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Number(n) => n.as_f64(),
+        // Strings parse-coerce to numbers — covers "12.5" and "0" returning
+        // from JSON APIs that quote numerics. Non-numeric strings → None.
+        Value::String(s) => s.parse::<f64>().ok(),
+        Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn snap() -> Value {
+        json!({
+            "weather": { "precip_chance_pct": 30, "alerts": null, "temp_f": "72.5" },
+            "river": { "go": true, "level_ft": 9.4 },
+        })
+    }
+
+    #[test]
+    fn exists_true_when_path_resolves() {
+        let vw = VisibleWhen {
+            path: "$.weather.alerts".into(),
+            op: "exists".into(),
+            value: Value::Null,
+        };
+        assert!(vw.evaluate(&snap()));
+    }
+
+    #[test]
+    fn exists_false_when_missing() {
+        let vw = VisibleWhen {
+            path: "$.weather.does_not_exist".into(),
+            op: "exists".into(),
+            value: Value::Null,
+        };
+        assert!(!vw.evaluate(&snap()));
+    }
+
+    #[test]
+    fn equality_with_bool_and_string() {
+        let vw_bool = VisibleWhen {
+            path: "$.river.go".into(),
+            op: "=".into(),
+            value: json!(true),
+        };
+        assert!(vw_bool.evaluate(&snap()));
+
+        let vw_neq = VisibleWhen {
+            path: "$.river.go".into(),
+            op: "!=".into(),
+            value: json!(false),
+        };
+        assert!(vw_neq.evaluate(&snap()));
+    }
+
+    #[test]
+    fn numeric_comparisons() {
+        let cases = [
+            (">", 0, true),
+            (">", 30, false),
+            (">=", 30, true),
+            ("<", 50, true),
+            ("<=", 30, true),
+            ("=", 30, true),
+            ("=", 25, false),
+        ];
+        for (op, val, want) in cases {
+            let vw = VisibleWhen {
+                path: "$.weather.precip_chance_pct".into(),
+                op: op.into(),
+                value: json!(val),
+            };
+            assert_eq!(vw.evaluate(&snap()), want, "op={op} val={val}");
+        }
+    }
+
+    #[test]
+    fn string_number_coerces_for_gt() {
+        // temp_f is "72.5" (string) — > 70 (number) should be true.
+        let vw = VisibleWhen {
+            path: "$.weather.temp_f".into(),
+            op: ">".into(),
+            value: json!(70),
+        };
+        assert!(vw.evaluate(&snap()));
+    }
+
+    #[test]
+    fn missing_path_hides() {
+        let vw = VisibleWhen {
+            path: "$.does.not.exist".into(),
+            op: ">".into(),
+            value: json!(0),
+        };
+        assert!(!vw.evaluate(&snap()));
+    }
+
+    #[test]
+    fn unknown_op_hides() {
+        let vw = VisibleWhen {
+            path: "$.river.go".into(),
+            op: "regex".into(),
+            value: json!(".*"),
+        };
+        assert!(!vw.evaluate(&snap()));
+    }
+
+    #[test]
+    fn type_mismatch_on_gt_hides() {
+        // Comparing a non-numeric string with > should hide.
+        let vw = VisibleWhen {
+            path: "$.weather.alerts".into(), // null in fixture
+            op: ">".into(),
+            value: json!(0),
+        };
+        assert!(!vw.evaluate(&snap()));
+    }
+
+    #[test]
+    fn cross_type_equality_via_stringification() {
+        // 30 == "30" — friendly forgiveness for stringified numerics.
+        let vw = VisibleWhen {
+            path: "$.weather.precip_chance_pct".into(),
+            op: "=".into(),
+            value: json!("30"),
+        };
+        assert!(vw.evaluate(&snap()));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let vw = VisibleWhen {
+            path: "$.x".into(),
+            op: ">=".into(),
+            value: json!(5),
+        };
+        let s = serde_json::to_string(&vw).unwrap();
+        let back: VisibleWhen = serde_json::from_str(&s).unwrap();
+        assert_eq!(vw, back);
+    }
+}

--- a/tests/compositor_tests.rs
+++ b/tests/compositor_tests.rs
@@ -152,6 +152,7 @@ async fn default_config_composite_returns_800x480_png() {
             plugin_instance_id: "river".to_string(),
             layout_variant: "full".to_string(),
             parent_id: None,
+            visible_when: None,
         }],
     };
 
@@ -192,6 +193,7 @@ async fn trip_planner_config_composite_returns_800x480_png() {
                 plugin_instance_id: "weather".to_string(),
                 layout_variant: "half_horizontal".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
             LayoutItem::PluginSlot {
                 id: "s1".to_string(),
@@ -200,6 +202,7 @@ async fn trip_planner_config_composite_returns_800x480_png() {
                 plugin_instance_id: "river".to_string(),
                 layout_variant: "quadrant".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
             LayoutItem::PluginSlot {
                 id: "s2".to_string(),
@@ -208,6 +211,7 @@ async fn trip_planner_config_composite_returns_800x480_png() {
                 plugin_instance_id: "ferry".to_string(),
                 layout_variant: "quadrant".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
         ],
     };
@@ -298,6 +302,7 @@ async fn compositor_runs_slots_concurrently_and_joins() {
                 plugin_instance_id: "weather".to_string(),
                 layout_variant: "half_horizontal".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
             LayoutItem::PluginSlot {
                 id: "s1".to_string(), z_index: 1,
@@ -305,6 +310,7 @@ async fn compositor_runs_slots_concurrently_and_joins() {
                 plugin_instance_id: "river".to_string(),
                 layout_variant: "quadrant".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
             LayoutItem::PluginSlot {
                 id: "s2".to_string(), z_index: 2,
@@ -312,6 +318,7 @@ async fn compositor_runs_slots_concurrently_and_joins() {
                 plugin_instance_id: "ferry".to_string(),
                 layout_variant: "quadrant".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
         ],
     };
@@ -370,6 +377,7 @@ async fn static_divider_composited_without_sidecar() {
             width: 800, height: 2,
             orientation: Some("horizontal".to_string()),
             parent_id: None,
+            visible_when: None,
         }],
     };
 
@@ -413,6 +421,7 @@ async fn static_text_renders_via_sidecar() {
             orientation: None,
             bold: None, italic: None, underline: None, font_family: None, color: None,
             parent_id: None,
+            visible_when: None,
         }],
     };
 
@@ -449,6 +458,7 @@ async fn mixed_layout_plugin_text_divider_composited_correctly() {
                 plugin_instance_id: "weather".to_string(),
                 layout_variant: "half_horizontal".to_string(),
                 parent_id: None,
+                visible_when: None,
             },
             LayoutItem::StaticText {
                 id: "t0".to_string(), z_index: 1,
@@ -458,12 +468,14 @@ async fn mixed_layout_plugin_text_divider_composited_correctly() {
                 orientation: None,
                 bold: None, italic: None, underline: None, font_family: None, color: None,
                 parent_id: None,
+                visible_when: None,
             },
             LayoutItem::StaticDivider {
                 id: "d0".to_string(), z_index: 2,
                 x: 0, y: 240, width: 800, height: 2,
                 orientation: Some("horizontal".to_string()),
                 parent_id: None,
+                visible_when: None,
             },
         ],
     };
@@ -538,6 +550,7 @@ async fn data_field_renders_extracted_value_via_sidecar() {
             orientation: None,
             bold: None, italic: None, underline: None, font_family: None, color: None,
             parent_id: None,
+            visible_when: None,
         }],
     };
 
@@ -587,6 +600,7 @@ async fn data_field_missing_mapping_renders_placeholder() {
             orientation: None,
             bold: None, italic: None, underline: None, font_family: None, color: None,
             parent_id: None,
+            visible_when: None,
         }],
     };
 
@@ -652,6 +666,7 @@ async fn data_field_with_label_renders_successfully() {
             orientation: None,
             bold: None, italic: None, underline: None, font_family: None, color: None,
             parent_id: None,
+            visible_when: None,
         }],
     };
 

--- a/tests/phase5_style_tests.rs
+++ b/tests/phase5_style_tests.rs
@@ -280,6 +280,7 @@ async fn compositor_wraps_sidecar_html_with_font_face() {
             font_family: Some("Inter".to_string()),
             color: None,
             parent_id: None,
+            visible_when: None,
         }],
     };
 
@@ -442,6 +443,7 @@ async fn compositor_emits_item_color_in_sidecar_html() {
             font_family: None,
             color: Some("#ff0000".to_string()),
             parent_id: None,
+            visible_when: None,
         }],
     };
 
@@ -482,6 +484,7 @@ fn layout_item_color_roundtrips_through_store() {
             font_family: None,
             color: Some("#ff0000".to_string()),
             parent_id: None,
+            visible_when: None,
         },
         LayoutItem::DataField {
             id: "d1".to_string(),
@@ -501,6 +504,7 @@ fn layout_item_color_roundtrips_through_store() {
             font_family: None,
             color: Some("#0033aa".to_string()),
             parent_id: None,
+            visible_when: None,
         },
     ];
 

--- a/tests/phase6_assets_tests.rs
+++ b/tests/phase6_assets_tests.rs
@@ -266,6 +266,7 @@ fn layout_item_image_roundtrips_through_store() {
         height: 80,
         asset_id: "asset-abc123".to_string(),
         parent_id: Some("group-1".to_string()),
+        visible_when: None,
     };
     store
         .upsert_layout(&LayoutConfig {
@@ -279,7 +280,7 @@ fn layout_item_image_roundtrips_through_store() {
     let loaded = store.get_layout("L1").unwrap().unwrap();
     assert_eq!(loaded.items.len(), 1);
     match &loaded.items[0] {
-        LayoutItem::Image { id, asset_id, x, y, width, height, parent_id, z_index } => {
+        LayoutItem::Image { id, asset_id, x, y, width, height, parent_id, z_index, .. } => {
             assert_eq!(id, "img-42");
             assert_eq!(asset_id, "asset-abc123");
             assert_eq!((*x, *y, *width, *height), (50, 60, 120, 80));

--- a/tests/phase7_conditional_tests.rs
+++ b/tests/phase7_conditional_tests.rs
@@ -1,0 +1,236 @@
+//! Phase 7 — visible_when + DataIcon integration tests.
+//!
+//! Each test maps to a red-green step in the Phase 7 implementation
+//! (see `docs/plugin-customization-design.md`). Unit tests for the
+//! `visible_when::evaluate` operator semantics live alongside the module
+//! itself; these are the wire / store / compositor integration checks.
+
+use cascades::layout_store::{LayoutConfig, LayoutItem, LayoutStore};
+use cascades::visible_when::VisibleWhen;
+use serde_json::json;
+use std::collections::HashMap;
+
+/// `visible_when` must roundtrip through SQLite — proves the JSON-encoded
+/// column is wired up in both the read and write paths.
+#[test]
+fn visible_when_roundtrips_through_layout_store() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let vw = VisibleWhen {
+        path: "$.weather.precip_chance_pct".to_string(),
+        op: ">".to_string(),
+        value: json!(50),
+    };
+    let original = LayoutItem::StaticText {
+        id: "txt".to_string(),
+        z_index: 0,
+        x: 0, y: 0, width: 100, height: 20,
+        text_content: "rain warning".to_string(),
+        font_size: 16,
+        orientation: None,
+        bold: None, italic: None, underline: None, font_family: None, color: None,
+        parent_id: None,
+        visible_when: Some(vw.clone()),
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(),
+            name: "L".into(),
+            items: vec![original],
+            updated_at: 0,
+        })
+        .unwrap();
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    assert_eq!(loaded.items.len(), 1);
+    let got = loaded.items[0].visible_when().expect("visible_when survived roundtrip");
+    assert_eq!(got, &vw);
+}
+
+/// Items without a clause must still load with `visible_when: None`. This
+/// guards against the additive-column migration breaking pre-Phase-7 rows.
+#[test]
+fn item_without_visible_when_loads_as_none() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let item = LayoutItem::StaticDivider {
+        id: "d".to_string(),
+        z_index: 0, x: 0, y: 0, width: 100, height: 4,
+        orientation: None,
+        parent_id: None,
+        visible_when: None,
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items: vec![item], updated_at: 0,
+        })
+        .unwrap();
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    assert!(loaded.items[0].visible_when().is_none());
+}
+
+/// `LayoutItem::DataIcon` must roundtrip with a populated `icon_map`.
+/// Mirrors Phase 6a's `layout_item_image_roundtrips_through_store`.
+#[test]
+fn data_icon_roundtrips_with_icon_map() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let mut icon_map = HashMap::new();
+    icon_map.insert("sun".to_string(), "asset-aaa".to_string());
+    icon_map.insert("rain".to_string(), "asset-bbb".to_string());
+    let original = LayoutItem::DataIcon {
+        id: "icon-1".to_string(),
+        z_index: 1, x: 10, y: 20, width: 64, height: 64,
+        field_mapping_id: "fm-weather-condition".to_string(),
+        icon_map: icon_map.clone(),
+        parent_id: None,
+        visible_when: None,
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items: vec![original], updated_at: 0,
+        })
+        .unwrap();
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    match &loaded.items[0] {
+        LayoutItem::DataIcon { id, field_mapping_id, icon_map: m, x, y, width, height, .. } => {
+            assert_eq!(id, "icon-1");
+            assert_eq!(field_mapping_id, "fm-weather-condition");
+            assert_eq!((*x, *y, *width, *height), (10, 20, 64, 64));
+            assert_eq!(m, &icon_map);
+        }
+        other => panic!("expected DataIcon, got {other:?}"),
+    }
+}
+
+/// The DB's `visible_when_json` column rejects a malformed JSON gracefully:
+/// the item loads with `visible_when: None` and a warning is logged. A
+/// hand-edited DB shouldn't crash the read path. We simulate by writing a
+/// row with a valid clause, corrupting the JSON via raw SQL, then re-reading.
+#[test]
+fn malformed_visible_when_json_loads_as_none() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let store = LayoutStore::open(&db_path).unwrap();
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items: vec![LayoutItem::StaticDivider {
+                id: "d".into(), z_index: 0, x: 0, y: 0, width: 100, height: 4,
+                orientation: None, parent_id: None,
+                visible_when: Some(VisibleWhen {
+                    path: "$.x".into(), op: "=".into(), value: json!(1),
+                }),
+            }],
+            updated_at: 0,
+        })
+        .unwrap();
+
+    // Corrupt the visible_when_json column directly.
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE layout_items SET visible_when_json = '{not-valid-json' WHERE id = 'd'",
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    assert_eq!(loaded.items.len(), 1);
+    assert!(
+        loaded.items[0].visible_when().is_none(),
+        "malformed clause must downgrade to None, not panic",
+    );
+}
+
+/// `LayoutItem::Group` skips visible_when by design — hiding a group
+/// separately from its children is a different (cascading) feature deferred
+/// from v1. The accessor returns None even though Group has no field.
+#[test]
+fn group_visible_when_is_always_none() {
+    let g = LayoutItem::Group {
+        id: "g".to_string(),
+        z_index: 0, x: 0, y: 0, width: 100, height: 100,
+        plugin_instance_id: None, label: None, background: None, parent_id: None,
+    };
+    assert!(g.visible_when().is_none());
+}
+
+/// All six non-Group variants must roundtrip `visible_when` through SQLite.
+/// Each variant has its own serde-derived field list and its own write-path
+/// INSERT; copy-paste mistakes between them won't surface in serde tests
+/// because each derive is independent. Cover them all in one test so a
+/// regression on any single variant fails loudly.
+#[test]
+fn visible_when_roundtrips_on_every_non_group_variant() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    fn vw(suffix: &str) -> Option<VisibleWhen> {
+        Some(VisibleWhen {
+            path: format!("$.test.{suffix}"),
+            op: "exists".into(),
+            value: serde_json::Value::Null,
+        })
+    }
+
+    let items = vec![
+        LayoutItem::PluginSlot {
+            id: "ps".into(), z_index: 0, x: 0, y: 0, width: 100, height: 100,
+            plugin_instance_id: "x".into(), layout_variant: "full".into(),
+            parent_id: None, visible_when: vw("plugin_slot"),
+        },
+        LayoutItem::StaticText {
+            id: "st".into(), z_index: 1, x: 0, y: 0, width: 100, height: 20,
+            text_content: "t".into(), font_size: 16, orientation: None,
+            bold: None, italic: None, underline: None, font_family: None, color: None,
+            parent_id: None, visible_when: vw("static_text"),
+        },
+        LayoutItem::StaticDateTime {
+            id: "sdt".into(), z_index: 2, x: 0, y: 0, width: 100, height: 20,
+            font_size: 16, format: None, orientation: None,
+            bold: None, italic: None, underline: None, font_family: None, color: None,
+            parent_id: None, visible_when: vw("static_datetime"),
+        },
+        LayoutItem::StaticDivider {
+            id: "sd".into(), z_index: 3, x: 0, y: 0, width: 100, height: 4,
+            orientation: None, parent_id: None,
+            visible_when: vw("static_divider"),
+        },
+        LayoutItem::DataField {
+            id: "df".into(), z_index: 4, x: 0, y: 0, width: 100, height: 20,
+            field_mapping_id: "fm".into(), font_size: 16,
+            format_string: "{{value}}".into(), label: None, orientation: None,
+            bold: None, italic: None, underline: None, font_family: None, color: None,
+            parent_id: None, visible_when: vw("data_field"),
+        },
+        LayoutItem::Image {
+            id: "img".into(), z_index: 5, x: 0, y: 0, width: 100, height: 100,
+            asset_id: "asset-x".into(),
+            parent_id: None, visible_when: vw("image"),
+        },
+    ];
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items, updated_at: 0,
+        })
+        .unwrap();
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    assert_eq!(loaded.items.len(), 6);
+    // Every loaded item must carry the visible_when its predecessor put in.
+    let suffixes = ["plugin_slot", "static_text", "static_datetime",
+                    "static_divider", "data_field", "image"];
+    for (it, suffix) in loaded.items.iter().zip(suffixes.iter()) {
+        let got = it.visible_when().unwrap_or_else(|| panic!("variant {suffix:?} lost visible_when"));
+        assert_eq!(got.path, format!("$.test.{suffix}"));
+        assert_eq!(got.op, "exists");
+    }
+}

--- a/tests/server_acceptance_tests.rs
+++ b/tests/server_acceptance_tests.rs
@@ -1129,6 +1129,7 @@ async fn webhook_invalidates_image_cache_for_affected_display() {
                 plugin_instance_id: "river".to_string(),
                 layout_variant: "full".to_string(),
                 parent_id: None,
+                visible_when: None,
             }],
             updated_at: 0,
         })


### PR DESCRIPTION
## Summary

Backend half of **Phase 7** from `docs/plugin-customization-design.md`. Adds two related primitives that share a per-render JSONPath evaluation pass:

1. **`visible_when { path, op, value }`** on every non-Group `LayoutItem` variant — compositor evaluates against a unified instance-data snapshot, items resolving false are skipped (no sidecar work, no paint).
2. **`LayoutItem::DataIcon`** — extracts a string value from cached source data via a `FieldMapping`, looks it up in `icon_map` to choose which `Asset` to render. Falls back to a blank rectangle for unmapped values (same defensive contract as missing-asset on `Image`).

This PR ships **without admin-UI surface** — same a/b split as Phases 5 and 6. Phase 7b (next PR) lands the inspector controls (`Show only when…` + `DataIcon` map editor) in `templates/admin.html`.

> **Base branch:** This PR targets `feature/phase-6-assets-image` (PR #7) since 7 builds on Phase 6's `LayoutItem::Image` + `AssetStore` work. After #7 merges to main, GitHub auto-retargets this PR.

## Design decisions called out (advisor-vetted)

- **Group items don't carry `visible_when`.** Hiding a group separately from its children is a different (cascading) feature deliberately deferred from v1.
- **Missing data → hide; malformed JSON → no clause.** Two distinct cases:
  - The clause's `path` doesn't resolve in the snapshot → "fail closed," item hides. Matches the design doc's intent for "data hasn't arrived yet."
  - The DB column has malformed JSON → log + load as `None` (renders unconditionally). Matches "operational damage outside the admin UI's control" — falling back to the user's pre-clause behavior is the least-surprising default.
- **Cross-type equality coerces.** `30 == "30"` returns true. Forgiving, matches the rest of the codebase's JSON handling.
- **`exists`** ignores `value`. Wire shape stays uniform — `(path, op, value)` regardless of operator — so the admin UI inspector control is one form.
- **DataIcon `icon_map`** = `HashMap<String, String>` (value → asset_id), serialized as JSON in the new `icon_map_json` column.
- **DataIcon path resolution edge cases:** `$.water_level`, `$.values[0]`, and `$.[0]` all build correctly — the trim/branch dance avoids `$.<src>.[0]` (ill-formed).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — **494/494** passing (was 475; +10 visible_when unit, +6 phase7 integration, +3 compositor render).
- [x] **End-to-end smoke test** via the running server:
  - Posted a layout with a hidden divider (`visible_when:{path:"$.does.not.exist",op:">",value:0}`)
  - Rendered via `POST /api/admin/preview/{id}` → 800×480 grayscale PNG
  - **Pixel-level assertion:** y=51 (visible divider) is black; y=101 (hidden divider) is white. Visible_when filter works end-to-end.
  - DataIcon JSON round-trip via `POST/GET /api/admin/layout` preserves all fields including `icon_map`.
- [x] DB pollution from smoke testing cleaned before commit.

## What 7b adds (next PR)

- Inspector "Show only when…" control on every item (path picker + operator dropdown + literal input)
- DataIcon palette entry + drag-to-canvas
- DataIcon inspector with map editor (value → asset dropdown)
- `admin_html_contains_phase7b_markers` smoke test (same pattern as 5b/6b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)