### PR TITLE
feat(phase8a): default_elements_hash + reset-to-defaults endpoint

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -189,6 +189,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/admin/layout/{id}/item", post(admin_post_item))
         .route("/api/admin/layout/{id}/item/{item_id}", put(admin_put_item))
         .route("/api/admin/layout/{id}/item/{item_id}", delete(admin_delete_item))
+        .route(
+            "/api/admin/layout/{id}/groups/{group_id}/reset",
+            post(admin_reset_group_to_defaults),
+        )
         // Source presets
         .route("/api/admin/presets", get(admin_list_presets))
         .route("/api/admin/sources/from-preset", post(admin_create_from_preset))
@@ -837,6 +841,13 @@ struct ItemPayload {
     /// for that variant; ignored on others.
     #[serde(default)]
     icon_map: Option<std::collections::HashMap<String, String>>,
+    /// Phase 8: hash of the plugin's `default_elements` at spawn / last-reset
+    /// time. Only meaningful on Group items with a `plugin_instance_id`.
+    /// Carried through both directions of the wire so the client can stamp
+    /// it after a fresh spawn (it fetches the manifest hash from the
+    /// `/default_elements` endpoint and round-trips it back).
+    #[serde(default)]
+    default_elements_hash: Option<String>,
 }
 
 impl ItemPayload {
@@ -939,6 +950,10 @@ impl ItemPayload {
                 label: self.label,
                 background: self.background,
                 parent_id: self.parent_id,
+                default_elements_hash: self.default_elements_hash,
+                // `defaults_stale` is computed at GET-layout time; never
+                // set from a write payload.
+                defaults_stale: None,
             }),
             "image" => Ok(LayoutItem::Image {
                 id: self.id,
@@ -1264,7 +1279,35 @@ async fn admin_get_layout(
     }
 
     match app.layout_store.get_layout(&id) {
-        Ok(Some(layout)) => Json(layout).into_response(),
+        Ok(Some(mut layout)) => {
+            // Phase 8: decorate plugin-bound Group items with `defaults_stale`
+            // so the admin UI can show a "Plugin defaults updated" badge
+            // without a second roundtrip per group. Computed by comparing the
+            // stored hash to the registry's current hash for the same plugin.
+            //
+            // Fail-closed semantics: if the registry doesn't know the plugin
+            // (e.g. instance_store has it but plugin_registry doesn't),
+            // `defaults_stale` stays None — we can't tell, so we don't claim.
+            for item in layout.items.iter_mut() {
+                if let LayoutItem::Group {
+                    plugin_instance_id: Some(pi),
+                    default_elements_hash: Some(stored),
+                    defaults_stale,
+                    ..
+                } = item
+                {
+                    // Resolve instance → plugin_id → current hash. Same lookup
+                    // chain as `admin_get_default_elements`.
+                    if let Ok(Some(inst)) = app.instance_store.get_instance(pi)
+                        && let Some(current) =
+                            app.plugin_registry.default_elements_hash(&inst.plugin_id)
+                    {
+                        *defaults_stale = Some(current != *stored);
+                    }
+                }
+            }
+            Json(layout).into_response()
+        }
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
         Err(e) => {
             log::error!("admin_get_layout '{}': {}", id, e);
@@ -1539,7 +1582,18 @@ async fn admin_get_default_elements(
     };
 
     let Some(def) = app.plugin_registry.get(&instance.plugin_id) else {
-        return Json(Vec::<DefaultElementResponse>::new()).into_response();
+        return Json(DefaultElementsResponse {
+            elements: Vec::new(),
+            default_elements_hash: None,
+        })
+        .into_response();
+    };
+    // Phase 8: bundle the manifest hash with the elements so the JS spawn
+    // helper can stamp it on the new Group row in a single fetch.
+    let default_elements_hash = if def.default_elements.is_empty() {
+        None
+    } else {
+        Some(crate::plugin_registry::default_elements_hash(&def.default_elements))
     };
 
     let mut out: Vec<DefaultElementResponse> = Vec::with_capacity(def.default_elements.len());
@@ -1580,7 +1634,11 @@ async fn admin_get_default_elements(
         });
     }
 
-    Json(out).into_response()
+    Json(DefaultElementsResponse {
+        elements: out,
+        default_elements_hash,
+    })
+    .into_response()
 }
 
 /// Deterministic field-mapping id derived from `(data_source_id, json_path)`.
@@ -1593,7 +1651,330 @@ fn stable_field_mapping_id(data_source_id: &str, json_path: &str) -> String {
     format!("fm-{data_source_id}-{sanitized}")
 }
 
+/// Phase 8: spawn fresh child `LayoutItem`s from a plugin manifest's
+/// `default_elements`, positioned so their bounding box's top-left sits at
+/// `(group_origin_x, group_origin_y)`. Returns the children alongside the
+/// computed (width, height) of their union — the caller is expected to
+/// resize the parent Group to match.
+///
+/// Mirrors the client-side translation in `spawnPluginAt` (see
+/// `templates/admin.html`). The two implementations exist in parallel
+/// because Phase 8a is server-only — initial spawns still happen in JS, but
+/// `POST /admin/layout/{lid}/groups/{gid}/reset` needs to do the same work
+/// without round-tripping through the client. **If you change either, change
+/// both.** A divergence will silently produce different geometry on reset
+/// vs. on first drop, which is exactly the regret-class bug Phase 8 was
+/// meant to prevent.
+fn spawn_children_from_manifest(
+    elements: &[DefaultElement],
+    instance_id: &str,
+    group_id: &str,
+    group_origin_x: i32,
+    group_origin_y: i32,
+    base_z: i32,
+    layout_store: &LayoutStore,
+) -> Result<(Vec<LayoutItem>, i32, i32), String> {
+    if elements.is_empty() {
+        return Ok((Vec::new(), 0, 0));
+    }
+    // Compute the manifest bounding-box so we can translate to the group's
+    // existing origin (a "reset" must not jump the group on screen).
+    let min_x = elements.iter().map(|e| e.x).min().unwrap_or(0);
+    let min_y = elements.iter().map(|e| e.y).min().unwrap_or(0);
+    let max_x = elements.iter().map(|e| e.x + e.width).max().unwrap_or(0);
+    let max_y = elements.iter().map(|e| e.y + e.height).max().unwrap_or(0);
+    let union_w = (max_x - min_x).max(20);
+    let union_h = (max_y - min_y).max(20);
+
+    let mut children = Vec::with_capacity(elements.len());
+    for (i, el) in elements.iter().enumerate() {
+        let child_id = format!(
+            "{group_id}-c{i}-{ts:x}",
+            // Tag with a low-bits timestamp so a reset doesn't collide with
+            // any pre-existing item id from the wiped-out tree. Globally
+            // unique by construction.
+            ts = unix_now_millis()
+        );
+        let x = group_origin_x + (el.x - min_x);
+        let y = group_origin_y + (el.y - min_y);
+        let z_index = base_z + (i as i32) + 1;
+        let parent = Some(group_id.to_string());
+
+        let item = match el.kind.as_str() {
+            "static_text" => LayoutItem::StaticText {
+                id: child_id,
+                z_index,
+                x,
+                y,
+                width: el.width,
+                height: el.height,
+                text_content: el.text_content.clone().unwrap_or_default(),
+                font_size: el.font_size.unwrap_or(16),
+                orientation: el.orientation.clone(),
+                bold: None, italic: None, underline: None,
+                font_family: None, color: None,
+                parent_id: parent,
+                visible_when: None,
+            },
+            "static_datetime" => LayoutItem::StaticDateTime {
+                id: child_id,
+                z_index,
+                x,
+                y,
+                width: el.width,
+                height: el.height,
+                font_size: el.font_size.unwrap_or(16),
+                format: el.format.clone(),
+                orientation: el.orientation.clone(),
+                bold: None, italic: None, underline: None,
+                font_family: None, color: None,
+                parent_id: parent,
+                visible_when: None,
+            },
+            "static_divider" => LayoutItem::StaticDivider {
+                id: child_id,
+                z_index,
+                x,
+                y,
+                width: el.width,
+                height: el.height,
+                orientation: el.orientation.clone(),
+                parent_id: parent,
+                visible_when: None,
+            },
+            "data_field" => {
+                // Same upsert logic as admin_get_default_elements — every
+                // data_field child needs a stable field_mapping_id row in
+                // data_source_fields before the layout is saved.
+                let path = el.field_path.as_deref().ok_or_else(|| {
+                    format!("data_field default_element missing field_path (kind={})", el.kind)
+                })?;
+                let name = el.label.clone().unwrap_or_else(|| path.to_string());
+                let fm_id = stable_field_mapping_id(instance_id, path);
+                let fm = layout_store
+                    .upsert_field_mapping_by_path(&fm_id, instance_id, "builtin", &name, path)
+                    .map_err(|e| format!("upsert field mapping for '{path}': {e}"))?;
+                LayoutItem::DataField {
+                    id: child_id,
+                    z_index,
+                    x,
+                    y,
+                    width: el.width,
+                    height: el.height,
+                    field_mapping_id: fm.id,
+                    font_size: el.font_size.unwrap_or(16),
+                    format_string: el.format_string.clone().unwrap_or_else(|| "{{value}}".to_string()),
+                    label: el.label.clone(),
+                    orientation: el.orientation.clone(),
+                    bold: None, italic: None, underline: None,
+                    font_family: None, color: None,
+                    parent_id: parent,
+                    visible_when: None,
+                }
+            }
+            other => {
+                return Err(format!(
+                    "default_elements: unsupported kind '{other}' (expected static_text / \
+                     static_datetime / static_divider / data_field)"
+                ));
+            }
+        };
+        children.push(item);
+    }
+    Ok((children, union_w, union_h))
+}
+
+fn unix_now_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+/// Wire shape for `POST /api/admin/layout/{id}/groups/{group_id}/reset`.
+/// Returned to the client so the UI can show "discarded N items" + refresh
+/// without a follow-up GET.
+#[derive(Debug, Serialize)]
+struct ResetGroupResponse {
+    /// Number of descendant items wiped (transitive count of items whose
+    /// parent chain reached the target group).
+    discarded_count: usize,
+    /// Hash that was stamped on the group post-reset — equals the manifest's
+    /// current hash. Surfaced so the UI can confirm staleness cleared.
+    default_elements_hash: String,
+    /// Updated full layout (admin UIs that hold a local copy can replace
+    /// state without a separate GET).
+    layout: LayoutConfig,
+}
+
+/// `POST /api/admin/layout/{id}/groups/{group_id}/reset` — wipe a plugin
+/// group's children and respawn from the manifest's `default_elements`,
+/// stamping the current hash. **Destructive:** every descendant of the
+/// group (transitive) is removed, including any user-added items inside
+/// the plugin region.
+///
+/// Returns 404 when the layout, group, plugin instance, or plugin definition
+/// can't be found. Returns 400 when the group has no `plugin_instance_id`
+/// (resetting a hand-built group is meaningless) or when the plugin has no
+/// `default_elements` to spawn.
+async fn admin_reset_group_to_defaults(
+    headers: HeaderMap,
+    Path((layout_id, group_id)): Path<(String, String)>,
+    State(app): State<Arc<AppState>>,
+) -> impl IntoResponse {
+    if !is_admin_authorized(&headers, &app.api_key) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    // Read the layout (returns 404 if missing).
+    let mut layout = match app.layout_store.get_layout(&layout_id) {
+        Ok(Some(l)) => l,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            log::error!("admin_reset_group_to_defaults get_layout '{layout_id}': {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    // Locate the target Group + capture its origin so respawn keeps it in
+    // place. We need a copy of the geometry before we mutate the items vec.
+    let (group_origin_x, group_origin_y, group_z, instance_id) = {
+        let g = layout.items.iter().find(|it| it.id() == group_id);
+        let Some(LayoutItem::Group {
+            x, y, z_index, plugin_instance_id: Some(pi), ..
+        }) = g
+        else {
+            return Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from(
+                    "group not found or has no plugin_instance_id".to_string(),
+                ))
+                .unwrap();
+        };
+        (*x, *y, *z_index, pi.clone())
+    };
+
+    // Resolve plugin definition.
+    let instance = match app.instance_store.get_instance(&instance_id) {
+        Ok(Some(i)) => i,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            log::error!("admin_reset_group_to_defaults get_instance '{instance_id}': {e}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    let Some(def) = app.plugin_registry.get(&instance.plugin_id) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    if def.default_elements.is_empty() {
+        return Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Body::from(
+                "plugin has no default_elements; nothing to spawn".to_string(),
+            ))
+            .unwrap();
+    }
+
+    // Compute the hash from the same manifest snapshot we're about to spawn
+    // from — so a registry reload mid-request can't desync the stamp.
+    let new_hash = crate::plugin_registry::default_elements_hash(&def.default_elements);
+
+    // Wipe descendants — collect all transitive children of the group.
+    let descendants = collect_descendants(&layout.items, &group_id);
+    let discarded_count = descendants.len();
+    layout.items.retain(|it| !descendants.contains(it.id()));
+
+    // Spawn fresh children from the manifest snapshot.
+    let (children, union_w, union_h) = match spawn_children_from_manifest(
+        &def.default_elements,
+        &instance_id,
+        &group_id,
+        group_origin_x,
+        group_origin_y,
+        group_z,
+        &app.layout_store,
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            log::error!("admin_reset_group_to_defaults spawn_children: {e}");
+            return Response::builder()
+                .status(StatusCode::UNPROCESSABLE_ENTITY)
+                .body(Body::from(format!("spawn from manifest failed: {e}")))
+                .unwrap();
+        }
+    };
+
+    // Update the group: stamp the new hash and resize to the children's
+    // union so the visual frame still encloses everything that was spawned.
+    if let Some(LayoutItem::Group {
+        width,
+        height,
+        default_elements_hash,
+        ..
+    }) = layout.items.iter_mut().find(|it| it.id() == group_id)
+    {
+        *width = union_w;
+        *height = union_h;
+        *default_elements_hash = Some(new_hash.clone());
+    }
+
+    // Append the new children. `upsert_layout` will sort by z_index on read.
+    layout.items.extend(children);
+
+    if let Err(e) = app.layout_store.upsert_layout(&layout) {
+        log::error!("admin_reset_group_to_defaults upsert_layout: {e}");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Return the saved layout (re-fetched so the caller sees exactly what
+    // was persisted, including any default ordering applied by the store).
+    let saved = match app.layout_store.get_layout(&layout_id) {
+        Ok(Some(l)) => l,
+        _ => layout, // best-effort fallback if re-read fails
+    };
+
+    Json(ResetGroupResponse {
+        discarded_count,
+        default_elements_hash: new_hash,
+        layout: saved,
+    })
+    .into_response()
+}
+
+/// Collect transitive descendant ids of `group_id` from the items list. Does
+/// not include the group itself. Order is unspecified.
+fn collect_descendants(items: &[LayoutItem], group_id: &str) -> std::collections::HashSet<String> {
+    use std::collections::{HashSet, VecDeque};
+    let mut out: HashSet<String> = HashSet::new();
+    let mut frontier: VecDeque<String> = VecDeque::new();
+    frontier.push_back(group_id.to_string());
+    while let Some(parent) = frontier.pop_front() {
+        for it in items {
+            if it.parent_id() == Some(parent.as_str())
+                && out.insert(it.id().to_string())
+            {
+                frontier.push_back(it.id().to_string());
+            }
+        }
+    }
+    out
+}
+
 /// Wire shape for `GET /api/admin/plugins/{id}/default_elements`.
+///
+/// Phase 8 promoted the response from a bare `Vec<DefaultElementResponse>` to
+/// `{ elements, default_elements_hash }` so the admin UI can stamp the hash
+/// on a freshly-spawned plugin Group without a second roundtrip. The hash is
+/// `None` when the plugin has no `default_elements` (legacy single-PluginSlot
+/// drop path).
+#[derive(Debug, Serialize)]
+struct DefaultElementsResponse {
+    elements: Vec<DefaultElementResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    default_elements_hash: Option<String>,
+}
+
+/// One entry inside [`DefaultElementsResponse::elements`].
 #[derive(Debug, Serialize)]
 struct DefaultElementResponse {
     #[serde(flatten)]
@@ -3871,7 +4252,15 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let bytes = response.into_body().collect().await.unwrap().to_bytes();
         let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert!(body.is_array(), "default_elements should return a JSON array");
+        // Phase 8: response is `{ elements: [...], default_elements_hash: "..." }`.
+        // The hash field is omitted when no default_elements are declared
+        // (skip_serializing_if). Test fixture's "weather" plugin has no
+        // default_elements registered, so we just assert the envelope shape.
+        assert!(body.is_object(), "default_elements should return a JSON object");
+        assert!(
+            body.get("elements").map(|v| v.is_array()).unwrap_or(false),
+            "response should have an 'elements' array; got {body}"
+        );
     }
 
     #[tokio::test]
@@ -4375,5 +4764,277 @@ mod tests {
                 "itemsToPayload missing visible_when emission");
         assert!(ADMIN_HTML.contains("item.type === 'data_icon' ? (item.icon_map"),
                 "itemsToPayload missing icon_map emission for data_icon");
+    }
+
+    /// Phase 8a smoke test — asserts the bundled admin template's data-flow
+    /// changes for the new `/default_elements` wire shape and the
+    /// `default_elements_hash` round-trip. Inspector UI (badge + Reset
+    /// button) lands in 8b; this test is intentionally narrow and only
+    /// covers the JS pieces that the 8a backend depends on. A regression
+    /// here would silently break plugin spawns until 8b ships.
+    #[test]
+    fn admin_html_contains_phase8a_markers() {
+        // spawnPluginAt reads the new envelope shape.
+        assert!(ADMIN_HTML.contains("body.elements"),
+                "spawnPluginAt missing `body.elements` (new wire shape)");
+        assert!(ADMIN_HTML.contains("body.default_elements_hash"),
+                "spawnPluginAt missing default_elements_hash extraction");
+        // Hash is stamped on the spawned Group.
+        assert!(ADMIN_HTML.contains("default_elements_hash: defaultElementsHash"),
+                "spawnPluginAt not stamping default_elements_hash on Group");
+
+        // Both directions of the wire carry the hash.
+        assert!(ADMIN_HTML.contains("default_elements_hash: item.default_elements_hash"),
+                "apiToItems missing default_elements_hash hydration");
+        assert!(ADMIN_HTML.contains("isGroup ? (item.default_elements_hash || null)"),
+                "itemsToPayload missing default_elements_hash emission for Groups");
+
+        // Ephemeral defaults_stale flag is read but never written.
+        assert!(ADMIN_HTML.contains("defaults_stale:        !!item.defaults_stale"),
+                "apiToItems missing defaults_stale coercion");
+    }
+
+    // ── Phase 8: reset-to-defaults endpoint + GET-layout decoration ───────
+
+    fn weather_default_elements() -> Vec<DefaultElement> {
+        vec![
+            DefaultElement {
+                kind: "static_text".to_string(),
+                x: 0, y: 0, width: 200, height: 24,
+                z_index: 0,
+                field_path: None, label: None, format_string: None,
+                font_size: Some(20),
+                text_content: Some("Forecast".to_string()),
+                format: None,
+                orientation: None,
+            },
+            DefaultElement {
+                kind: "static_divider".to_string(),
+                x: 0, y: 30, width: 200, height: 2,
+                z_index: 1,
+                field_path: None, label: None, format_string: None,
+                font_size: None,
+                text_content: None, format: None,
+                orientation: Some("horizontal".to_string()),
+            },
+        ]
+    }
+
+    /// Register the `weather` plugin with the test registry so the reset
+    /// endpoint can resolve `default_elements`. Uses the public `insert`
+    /// helper rather than TOML so tests stay self-contained.
+    fn register_weather_plugin(state: &Arc<AppState>) {
+        use crate::plugin_registry::{DataStrategy, PluginDefinition};
+        let def = PluginDefinition {
+            id: "weather".to_string(),
+            name: "Weather".to_string(),
+            description: String::new(),
+            source: "weather".to_string(),
+            refresh_interval_secs: 300,
+            data_strategy: DataStrategy::Polling,
+            template_full: None,
+            template_half_horizontal: None,
+            template_half_vertical: None,
+            template_quadrant: None,
+            criteria: Vec::new(),
+            settings_schema: Vec::new(),
+            default_elements: weather_default_elements(),
+        };
+        state.plugin_registry.insert(def);
+    }
+
+    /// `POST /admin/layout/{id}/groups/{gid}/reset` wipes children, respawns
+    /// from the manifest, and stamps the current hash on the group.
+    #[tokio::test]
+    async fn admin_reset_group_wipes_children_and_stamps_hash() {
+        let (state, _dir) = make_writable_test_state();
+        register_weather_plugin(&state);
+        let app = build_router(Arc::clone(&state));
+
+        // Pre-populate: a layout with a weather Group + one stale child the
+        // user "added" inside the group; reset must remove that child too.
+        let layout = LayoutConfig {
+            id: "L".to_string(),
+            name: "L".to_string(),
+            updated_at: 0,
+            items: vec![
+                LayoutItem::Group {
+                    id: "g0".into(),
+                    z_index: 0, x: 50, y: 60, width: 200, height: 50,
+                    plugin_instance_id: Some("weather".into()),
+                    label: Some("Weather".into()),
+                    background: Some("card".into()),
+                    parent_id: None,
+                    default_elements_hash: Some("oldhash000000000".into()),
+                    defaults_stale: None,
+                },
+                LayoutItem::StaticText {
+                    id: "user-edit".into(),
+                    z_index: 1, x: 60, y: 70, width: 100, height: 20,
+                    text_content: "user added".into(),
+                    font_size: 14,
+                    orientation: None,
+                    bold: None, italic: None, underline: None, font_family: None, color: None,
+                    parent_id: Some("g0".into()),
+                    visible_when: None,
+                },
+            ],
+        };
+        state.layout_store.upsert_layout(&layout).unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/admin/layout/L/groups/g0/reset")
+            .header("x-api-key", "test-key")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK,
+            "reset endpoint should return 200");
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        // Discard count includes the user's hand-added child.
+        assert_eq!(body["discarded_count"].as_u64(), Some(1),
+            "expected 1 discarded child (the user-added text)");
+        // The stamped hash equals the current manifest hash.
+        let expected_hash = crate::plugin_registry::default_elements_hash(
+            &weather_default_elements(),
+        );
+        assert_eq!(body["default_elements_hash"].as_str(), Some(expected_hash.as_str()));
+
+        // The persisted layout has the manifest's children + the stamped hash.
+        let saved = state.layout_store.get_layout("L").unwrap().unwrap();
+        let group = saved.items.iter().find(|it| it.id() == "g0").unwrap();
+        match group {
+            LayoutItem::Group { default_elements_hash, x, y, .. } => {
+                assert_eq!(default_elements_hash.as_deref(), Some(expected_hash.as_str()));
+                // Origin preserved: reset must NOT jump the group on screen.
+                assert_eq!((*x, *y), (50, 60));
+            }
+            _ => panic!("g0 must still be a Group"),
+        }
+
+        // Children = exactly the manifest's elements. The user's "user-edit"
+        // child must be gone.
+        let children: Vec<_> = saved.items.iter()
+            .filter(|it| it.parent_id() == Some("g0"))
+            .collect();
+        assert_eq!(children.len(), 2, "expected 2 manifest children, got {children:?}");
+        assert!(saved.items.iter().all(|it| it.id() != "user-edit"),
+            "user-edit must be wiped");
+    }
+
+    /// Reset on a group with no `plugin_instance_id` returns 400 — there's
+    /// no manifest to spawn from.
+    #[tokio::test]
+    async fn admin_reset_group_rejects_handbuilt_group() {
+        let (state, _dir) = make_writable_test_state();
+        let app = build_router(Arc::clone(&state));
+
+        let layout = LayoutConfig {
+            id: "L".to_string(),
+            name: "L".to_string(),
+            updated_at: 0,
+            items: vec![LayoutItem::Group {
+                id: "g0".into(),
+                z_index: 0, x: 0, y: 0, width: 100, height: 100,
+                plugin_instance_id: None,
+                label: None, background: None, parent_id: None,
+                default_elements_hash: None, defaults_stale: None,
+            }],
+        };
+        state.layout_store.upsert_layout(&layout).unwrap();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/admin/layout/L/groups/g0/reset")
+            .header("x-api-key", "test-key")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// `GET /api/admin/layout/{id}` decorates plugin Groups with
+    /// `defaults_stale: true` when the stored hash differs from the
+    /// registry's current hash.
+    #[tokio::test]
+    async fn admin_get_layout_marks_stale_groups() {
+        let (state, _dir) = make_writable_test_state();
+        register_weather_plugin(&state);
+        let app = build_router(Arc::clone(&state));
+
+        let layout = LayoutConfig {
+            id: "L".to_string(),
+            name: "L".to_string(),
+            updated_at: 0,
+            items: vec![LayoutItem::Group {
+                id: "g0".into(),
+                z_index: 0, x: 0, y: 0, width: 200, height: 50,
+                plugin_instance_id: Some("weather".into()),
+                label: None, background: None, parent_id: None,
+                // Deliberately wrong hash → must report defaults_stale: true.
+                default_elements_hash: Some("zzzzzzzzzzzzzzzz".into()),
+                defaults_stale: None,
+            }],
+        };
+        state.layout_store.upsert_layout(&layout).unwrap();
+
+        let req = Request::builder()
+            .uri("/api/admin/layout/L")
+            .header("x-api-key", "test-key")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        let group = &body["items"][0];
+        assert_eq!(group["type"], "group");
+        assert_eq!(group["defaults_stale"].as_bool(), Some(true),
+            "stale group must be flagged: got {body}");
+    }
+
+    /// Conversely, a group whose stored hash matches the manifest's current
+    /// hash gets `defaults_stale: false` — the badge must clear after a reset.
+    #[tokio::test]
+    async fn admin_get_layout_marks_fresh_groups_not_stale() {
+        let (state, _dir) = make_writable_test_state();
+        register_weather_plugin(&state);
+        let app = build_router(Arc::clone(&state));
+
+        let current = crate::plugin_registry::default_elements_hash(
+            &weather_default_elements(),
+        );
+        let layout = LayoutConfig {
+            id: "L".to_string(),
+            name: "L".to_string(),
+            updated_at: 0,
+            items: vec![LayoutItem::Group {
+                id: "g0".into(),
+                z_index: 0, x: 0, y: 0, width: 200, height: 50,
+                plugin_instance_id: Some("weather".into()),
+                label: None, background: None, parent_id: None,
+                default_elements_hash: Some(current.clone()),
+                defaults_stale: None,
+            }],
+        };
+        state.layout_store.upsert_layout(&layout).unwrap();
+
+        let req = Request::builder()
+            .uri("/api/admin/layout/L")
+            .header("x-api-key", "test-key")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        let group = &body["items"][0];
+        assert_eq!(group["defaults_stale"].as_bool(), Some(false));
     }
 }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -1737,6 +1737,8 @@ mod tests {
             label: None,
             background: Some("card".to_string()),
             parent_id: None,
+            default_elements_hash: None,
+            defaults_stale: None,
         };
         let task_for_item = vec![None];
         let png = composite_to_png(&[item], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
@@ -1772,6 +1774,8 @@ mod tests {
             label: None,
             background: None,
             parent_id: None,
+            default_elements_hash: None,
+            defaults_stale: None,
         };
         let task_for_item = vec![None];
         let png = composite_to_png(&[item], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
@@ -1795,6 +1799,8 @@ mod tests {
             label: None,
             background: Some("card".to_string()),
             parent_id: None,
+            default_elements_hash: None,
+            defaults_stale: None,
         };
         // Child is a StaticDivider at z=1 inside the group.
         let child = LayoutItem::StaticDivider {

--- a/src/layout_store/mod.rs
+++ b/src/layout_store/mod.rs
@@ -255,6 +255,20 @@ pub enum LayoutItem {
         background: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_id: Option<String>,
+        /// Phase 8: hash of the plugin's `default_elements` at the time this
+        /// group was spawned (or last reset). Compared to the registry's
+        /// current hash to detect "Plugin defaults updated". Only meaningful
+        /// when `plugin_instance_id` is set; `None` on hand-built groups.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        default_elements_hash: Option<String>,
+        /// Phase 8: ephemeral flag — `Some(true)` when the registry's current
+        /// hash differs from `default_elements_hash`. Computed by the GET
+        /// layout handler at response time; **not persisted to SQLite** and
+        /// **never deserialised back** (the read path always sets this to
+        /// `None`). Skipped on serialise when `None` so the wire shape stays
+        /// minimal.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        defaults_stale: Option<bool>,
     },
 }
 
@@ -405,6 +419,11 @@ impl LayoutStore {
             // Phase 7: serialized HashMap<String,String> of value → asset_id
             // for LayoutItem::DataIcon.
             ("icon_map_json", "TEXT"),
+            // Phase 8: 16-char hex hash of the plugin manifest's
+            // `default_elements` at spawn / last-reset time. Compared to the
+            // registry's current hash to surface a "defaults updated" badge.
+            // Only meaningful on Group rows with `plugin_instance_id` set.
+            ("default_elements_hash", "TEXT"),
         ];
         for (col, typ) in &columns {
             let sql = format!("ALTER TABLE layout_items ADD COLUMN {col} {typ}");
@@ -470,7 +489,7 @@ impl LayoutStore {
                     field_mapping_id, format_string, label,
                     bold, italic, underline, font_family,
                     parent_id, background, color, asset_id,
-                    visible_when_json, icon_map_json
+                    visible_when_json, icon_map_json, default_elements_hash
              FROM layout_items
              WHERE layout_id = ?1
              ORDER BY z_index, id",
@@ -503,6 +522,7 @@ impl LayoutStore {
                 row.get::<_, Option<String>>(22)?,
                 row.get::<_, Option<String>>(23)?,
                 row.get::<_, Option<String>>(24)?,
+                row.get::<_, Option<String>>(25)?,
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -513,7 +533,7 @@ impl LayoutStore {
              field_mapping_id, format_string, label,
              bold, italic, underline, font_family,
              parent_id, background, color, asset_id,
-             visible_when_json, icon_map_json) in rows
+             visible_when_json, icon_map_json, default_elements_hash) in rows
         {
             let bold = bold.map(|v| v != 0);
             let italic = italic.map(|v| v != 0);
@@ -665,6 +685,11 @@ impl LayoutStore {
                     label,
                     background,
                     parent_id,
+                    default_elements_hash,
+                    // `defaults_stale` is computed at GET-layout time by
+                    // comparing the stored hash to the registry's current
+                    // hash; the storage layer always reads it as None.
+                    defaults_stale: None,
                 },
                 other => {
                     return Err(LayoutStoreError::InvalidItemType(other.to_string()))
@@ -836,15 +861,21 @@ impl LayoutStore {
                 LayoutItem::Group {
                     id, z_index, x, y, width, height,
                     plugin_instance_id, label, background, parent_id,
+                    default_elements_hash,
+                    // `defaults_stale` is ephemeral metadata for GET responses;
+                    // never persisted, so we drop it on write.
+                    defaults_stale: _,
                 } => {
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
-                          plugin_instance_id, label, background, parent_id)
-                         VALUES (?1, ?2, 'group', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                          plugin_instance_id, label, background, parent_id,
+                          default_elements_hash)
+                         VALUES (?1, ?2, 'group', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
                         params![
                             id, layout.id, z_index, x, y, width, height,
                             plugin_instance_id, label, background, parent_id,
+                            default_elements_hash,
                         ],
                     )?;
                 }
@@ -1653,6 +1684,8 @@ mod tests {
                     label: Some("Weather".to_string()),
                     background: Some("card".to_string()),
                     parent_id: None,
+                    default_elements_hash: None,
+                    defaults_stale: None,
                 },
                 LayoutItem::StaticText {
                     id: "t0".to_string(),
@@ -1697,6 +1730,8 @@ mod tests {
             label: Some("Hello".to_string()),
             background: None,
             parent_id: None,
+            default_elements_hash: None,
+            defaults_stale: None,
         };
         let json = serde_json::to_string(&item).unwrap();
         // None fields should be omitted by skip_serializing_if.
@@ -1727,6 +1762,8 @@ mod tests {
                     x: 0, y: 0, width: 200, height: 200,
                     plugin_instance_id: None, label: None, background: None,
                     parent_id: None,
+                    default_elements_hash: None,
+                    defaults_stale: None,
                 },
                 LayoutItem::StaticDivider {
                     id: "d".to_string(),

--- a/src/plugin_registry/mod.rs
+++ b/src/plugin_registry/mod.rs
@@ -217,6 +217,44 @@ fn default_refresh_interval() -> u64 {
     300
 }
 
+/// Compute a stable, content-addressed hash of a plugin's `default_elements`
+/// vector. Used by Phase 8 to detect when a plugin author has edited the
+/// manifest after a user already customised the spawned group: comparing the
+/// stored hash on the `Group` row to the registry's current hash drives the
+/// "Plugin defaults updated" badge.
+///
+/// # Hash contract — read this before adding fields to [`DefaultElement`]
+///
+/// - **Algorithm:** SHA-256 of `serde_json::to_string(elements)`, hex-encoded
+///   and truncated to the first 16 chars (64 bits — same compactness as the
+///   asset-id format introduced in Phase 6, sufficient for staleness diffs).
+/// - **Stability invariant:** `serde_json::to_string` MUST be deterministic.
+///   `DefaultElement` currently has no `HashMap`/`BTreeMap` fields, so
+///   serialization order matches struct field order. **Adding a `HashMap`
+///   field would silently break the hash** — different runs would compute
+///   different bytes for the same logical input. If you must add one, use
+///   `BTreeMap` (sorted) and add a regression test to
+///   `default_elements_hash_is_deterministic`.
+/// - **Versioning:** if you change the hash algorithm, every existing group
+///   row's `default_elements_hash` becomes stale. Either bump everything
+///   server-side or accept a one-time "defaults updated" wave.
+pub fn default_elements_hash(elements: &[DefaultElement]) -> String {
+    use sha2::{Digest, Sha256};
+    let json = serde_json::to_string(elements)
+        .expect("DefaultElement always serialises (no Maps in struct — see hash contract)");
+    let mut hasher = Sha256::new();
+    hasher.update(json.as_bytes());
+    let digest = hasher.finalize();
+    // Hex-encode the first 8 bytes (16 hex chars). Matches asset_id width
+    // and is more than enough entropy to avoid collisions across the small
+    // set of plugin manifests in any given install.
+    digest.iter().take(8).fold(String::with_capacity(16), |mut s, b| {
+        use std::fmt::Write;
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
 /// Intermediate structure for deserializing a `plugins.toml` or `plugins.d/*.toml` file.
 ///
 /// Each file may contain one or more `[[plugin]]` entries.
@@ -245,6 +283,26 @@ impl PluginRegistry {
     /// Return a clone of the definition for `id`, if present.
     pub fn get(&self, id: &str) -> Option<PluginDefinition> {
         self.inner.read().unwrap().get(id).cloned()
+    }
+
+    /// Insert (or overwrite) a plugin definition under its `id`. Primarily
+    /// useful for tests that need a registry pre-populated without going
+    /// through TOML parsing. Production code should use [`Self::load_file`]
+    /// or [`Self::load_from_config_dir`] so manifest validation runs.
+    pub fn insert(&self, def: PluginDefinition) {
+        self.inner.write().unwrap().insert(def.id.clone(), def);
+    }
+
+    /// Return the canonical hash of `id`'s `default_elements`, or `None` if
+    /// the plugin is unregistered or has no defaults. See
+    /// [`default_elements_hash`] for the hash contract.
+    pub fn default_elements_hash(&self, id: &str) -> Option<String> {
+        let guard = self.inner.read().unwrap();
+        let def = guard.get(id)?;
+        if def.default_elements.is_empty() {
+            return None;
+        }
+        Some(default_elements_hash(&def.default_elements))
     }
 
     /// Return all registered plugin definitions, sorted by ID.

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1540,6 +1540,15 @@ function apiToItems(apiItems) {
       icon_map:         item.icon_map            || {},
       parent_id:        item.parent_id           || null,
       background:       item.background          || null,
+      // Phase 8: hash of the plugin's default_elements at spawn / last reset.
+      // Only set on plugin-bound Group items; round-tripped on save.
+      default_elements_hash: item.default_elements_hash || null,
+      // Phase 8: ephemeral server-decorated flag. The `!!` coerces
+      // `undefined` → `false`, which is the correct default — without it,
+      // a missing field would be `undefined` and the badge UI would have to
+      // distinguish "no info" from "explicitly false." Server only sets
+      // this to true/false when the comparison is meaningful, never absent.
+      defaults_stale:        !!item.defaults_stale,
     };
   });
 }
@@ -1583,6 +1592,10 @@ function itemsToPayload(items) {
       icon_map:            item.type === 'data_icon' ? (item.icon_map || {}) : null,
       parent_id:           item.parent_id || null,
       background:          isGroup ? (item.background || null) : null,
+      // Phase 8: only Groups bound to a plugin instance carry a hash.
+      // Server ignores the field on non-Groups, but we explicitly emit null
+      // so the wire shape stays uniform and easy to inspect.
+      default_elements_hash: isGroup ? (item.default_elements_hash || null) : null,
     };
   });
 }
@@ -1673,11 +1686,17 @@ async function quickAdd(pluginId, variant) {
 // [[default_elements]]. Returns true if the group was spawned; false when the
 // caller should fall back to a single plugin_slot.
 async function spawnPluginAt(pluginId, variant, dropX, dropY) {
+  // Phase 8: response shape is `{ elements, default_elements_hash }`.
+  // The hash is round-tripped on save so the server can later detect
+  // "manifest changed since you spawned" and surface a Reset prompt.
   let elements = null;
+  let defaultElementsHash = null;
   try {
     const res = await apiFetch('/api/admin/plugins/' + encodeURIComponent(pluginId) + '/default_elements');
     if (!res.ok) return false;
-    elements = await res.json();
+    const body = await res.json();
+    elements = body.elements;
+    defaultElementsHash = body.default_elements_hash || null;
   } catch (e) {
     return false;
   }
@@ -1703,6 +1722,9 @@ async function spawnPluginAt(pluginId, variant, dropX, dropY) {
     plugin_id: pluginId, variant: variant,
     text: '', font_size: 24, orientation: 'horizontal',
     label: pluginId, background: 'card',
+    // Phase 8: stamp on the group at spawn so future save-cycles round-trip
+    // it. itemsToPayload will emit it back to the server.
+    default_elements_hash: defaultElementsHash,
   });
 
   elements.forEach(function(el, i) {

--- a/tests/phase7_conditional_tests.rs
+++ b/tests/phase7_conditional_tests.rs
@@ -158,6 +158,7 @@ fn group_visible_when_is_always_none() {
         id: "g".to_string(),
         z_index: 0, x: 0, y: 0, width: 100, height: 100,
         plugin_instance_id: None, label: None, background: None, parent_id: None,
+        default_elements_hash: None, defaults_stale: None,
     };
     assert!(g.visible_when().is_none());
 }

--- a/tests/phase8_recovery_tests.rs
+++ b/tests/phase8_recovery_tests.rs
@@ -1,0 +1,183 @@
+//! Phase 8 — Recovery & sync affordances integration tests.
+//!
+//! Covers the backend pieces that drive the admin UI's "Plugin defaults
+//! updated" badge and "Reset to plugin defaults" action:
+//!
+//! 1. `default_elements_hash()` is deterministic across runs.
+//! 2. The hash function detects edits — adding/changing fields shifts it.
+//! 3. The hash column round-trips through SQLite on Group rows.
+//! 4. Non-Group items don't carry a hash even if pre-Phase-8 rows exist.
+//!
+//! The HTTP-level reset-endpoint behaviour is exercised in api.rs unit
+//! tests where the full router + state are easy to spin up.
+
+use cascades::layout_store::{LayoutConfig, LayoutItem, LayoutStore};
+use cascades::plugin_registry::{default_elements_hash, DefaultElement};
+
+fn weather_manifest() -> Vec<DefaultElement> {
+    vec![
+        DefaultElement {
+            kind: "data_field".to_string(),
+            x: 0, y: 0, width: 200, height: 32,
+            z_index: 0,
+            field_path: Some("$.current.temp_f".to_string()),
+            label: Some("Temp".to_string()),
+            format_string: Some("{{value}}°F".to_string()),
+            font_size: Some(28),
+            text_content: None,
+            format: None,
+            orientation: Some("horizontal".to_string()),
+        },
+        DefaultElement {
+            kind: "static_text".to_string(),
+            x: 0, y: 40, width: 200, height: 24,
+            z_index: 1,
+            field_path: None, label: None, format_string: None,
+            font_size: Some(16),
+            text_content: Some("Conditions".to_string()),
+            format: None,
+            orientation: None,
+        },
+    ]
+}
+
+/// Hash of identical input must match — same struct, same hex output.
+/// Guards against a future refactor that introduces an unstable serialiser
+/// (e.g. `HashMap` field) without noticing.
+#[test]
+fn hash_is_deterministic() {
+    let m = weather_manifest();
+    let a = default_elements_hash(&m);
+    let b = default_elements_hash(&m);
+    assert_eq!(a, b, "same input must produce same hash");
+    assert_eq!(a.len(), 16, "hash is 16 hex chars (8 bytes)");
+    assert!(
+        a.chars().all(|c| c.is_ascii_hexdigit()),
+        "hash is hex-only: got {a}"
+    );
+}
+
+/// Editing the manifest changes the hash — what makes the badge work at all.
+/// We tweak each "interesting" field type to make sure none get accidentally
+/// excluded from serialisation (e.g. via a future `#[serde(skip)]`).
+#[test]
+fn hash_changes_when_manifest_changes() {
+    let base = default_elements_hash(&weather_manifest());
+
+    // 1. Change a primitive (font_size) on an existing element.
+    let mut m1 = weather_manifest();
+    m1[0].font_size = Some(40);
+    assert_ne!(base, default_elements_hash(&m1), "font_size delta must shift hash");
+
+    // 2. Change a string field.
+    let mut m2 = weather_manifest();
+    m2[1].text_content = Some("Forecast".to_string());
+    assert_ne!(base, default_elements_hash(&m2), "text_content delta must shift hash");
+
+    // 3. Add an element.
+    let mut m3 = weather_manifest();
+    m3.push(DefaultElement {
+        kind: "static_divider".to_string(),
+        x: 0, y: 70, width: 200, height: 4,
+        z_index: 2,
+        field_path: None, label: None, format_string: None, font_size: None,
+        text_content: None, format: None,
+        orientation: Some("horizontal".to_string()),
+    });
+    assert_ne!(base, default_elements_hash(&m3), "added element must shift hash");
+
+    // 4. Reorder elements — order matters in a Vec<DefaultElement> because
+    //    `z_index` and child-position are serialised positionally.
+    let mut m4 = weather_manifest();
+    m4.swap(0, 1);
+    assert_ne!(base, default_elements_hash(&m4), "reorder must shift hash");
+}
+
+/// Empty manifest gets no hash (the registry returns `None` for plugins
+/// with no defaults). Required so the legacy single-PluginSlot drop path
+/// doesn't accidentally start tagging groups with a hash.
+#[test]
+fn empty_manifest_still_hashes_to_a_value() {
+    // The free function still computes a hash for an empty vec — it's the
+    // *registry's* `default_elements_hash(plugin_id)` that returns None for
+    // empty inputs (so `/default_elements` returns `default_elements_hash:
+    // null`). We verify the free function stays well-defined so adding a
+    // hash later (when the manifest becomes non-empty) is backwards-safe.
+    let h = default_elements_hash(&[]);
+    assert_eq!(h.len(), 16);
+}
+
+/// `default_elements_hash` must round-trip through SQLite — if the column
+/// isn't selected on read, the badge logic gets None on every row and never
+/// fires. This is the same pattern as the Phase 7 visible_when roundtrip.
+#[test]
+fn default_elements_hash_roundtrips_on_group() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let stamp = "abc123def4567890".to_string();
+    let original = LayoutItem::Group {
+        id: "g0".into(),
+        z_index: 0, x: 10, y: 20, width: 300, height: 100,
+        plugin_instance_id: Some("weather".into()),
+        label: Some("Weather".into()),
+        background: Some("card".into()),
+        parent_id: None,
+        default_elements_hash: Some(stamp.clone()),
+        defaults_stale: None,
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items: vec![original], updated_at: 0,
+        })
+        .unwrap();
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    match &loaded.items[0] {
+        LayoutItem::Group { default_elements_hash, defaults_stale, .. } => {
+            assert_eq!(default_elements_hash.as_deref(), Some(stamp.as_str()),
+                "hash must survive write+read");
+            // The store always reads `defaults_stale` as None — it's
+            // computed at GET-layout time in the API handler, not stored.
+            assert!(defaults_stale.is_none(),
+                "defaults_stale is ephemeral; the store must never set it");
+        }
+        other => panic!("expected Group, got {other:?}"),
+    }
+}
+
+/// A Group with no `default_elements_hash` (the v1 case) still loads with
+/// `None` rather than e.g. an empty string. Guards against a write-side
+/// bug that would coerce `None` → `""` and confuse hash comparisons.
+#[test]
+fn pre_phase_8_group_loads_with_none_hash() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let original = LayoutItem::Group {
+        id: "g0".into(),
+        z_index: 0, x: 0, y: 0, width: 100, height: 100,
+        plugin_instance_id: None,
+        label: None,
+        background: None,
+        parent_id: None,
+        default_elements_hash: None,
+        defaults_stale: None,
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items: vec![original], updated_at: 0,
+        })
+        .unwrap();
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    match &loaded.items[0] {
+        LayoutItem::Group { default_elements_hash, .. } => {
+            assert!(default_elements_hash.is_none(),
+                "absent hash must read as None, not Some(\"\")");
+        }
+        other => panic!("expected Group, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Phase 8 backend — recovery & sync affordances. The user-visible features (defaults-updated badge, Reset button) land in 8b; this PR is the data + endpoint layer they depend on.

**What's new:**

- \`default_elements_hash\` column on \`layout_items\` (additive migration). Stamped on plugin-bound Group rows at spawn or reset; carried by the client through both directions of the wire.
- \`plugin_registry::default_elements_hash()\` — sha256 of canonical JSON, truncated to 16 hex chars. Documented "no Maps in DefaultElement" invariant so a future field addition that breaks determinism fails loud rather than silent.
- \`GET /api/admin/layout/{id}\` decorates plugin Groups with \`defaults_stale: bool\` by comparing the stored hash to the registry's current hash. Fail-closed: if the registry doesn't know the plugin, the flag stays absent.
- \`POST /api/admin/layout/{id}/groups/{group_id}/reset\` — wipes the group's transitive descendants and respawns from the manifest's \`default_elements\`, stamping the current hash and resizing the group to the manifest's bounding box.
- \`GET /api/admin/plugins/{id}/default_elements\` response promoted from \`Vec<DefaultElement>\` to \`{ elements, default_elements_hash }\`. Only consumer is the JS \`spawnPluginAt\`, updated in this PR.
- \`PluginRegistry::insert()\` — public test helper that bypasses TOML.

## Reviewer-relevant decisions

**1. Breaking wire-shape change for \`/default_elements\`.** Old: bare array. New: \`{ elements, default_elements_hash }\`. The only consumer is in-tree (the admin template's \`spawnPluginAt\`) and was updated in the same PR; binaries always ship together. Worth knowing before you grep for downstream consumers.

**2. No backfill for v1 plugin groups.** Existing groups stay with NULL hash until manually reset. The badge logic treats NULL as "can't tell" → no badge. More conservative than auto-stamping (which would claim "user accepted current defaults" without evidence). I consulted the advisor on this — they suggested backfill; I chose fail-closed because backfill would make the badge perma-quiet on rows that *might* genuinely be stale.

**3. Reset resizes the group to the manifest's bounding box.** If a user has manually grown the group to fit other content, reset shrinks it. Intentional ("reset to defaults"), but the 8b confirmation dialog will need to surface this. Test \`admin_reset_group_wipes_children_and_stamps_hash\` verifies origin (x, y) is preserved — only width/height change.

**4. Reset is destructive — including user-added items.** If a user dropped an Image inside the plugin group, reset wipes it. The endpoint returns \`discarded_count\` so the 8b dialog can show "This will discard 3 items including 1 image" before confirming.

## Test plan

- [x] \`cargo test\` — 505 tests pass (5 new Phase 8 integration tests + 5 new endpoint/smoke tests in api.rs)
- [x] \`cargo clippy --locked -- -D warnings\` — clean (matches CI)
- [x] Hash is deterministic across runs (\`hash_is_deterministic\`)
- [x] Hash changes on edits (\`hash_changes_when_manifest_changes\` exercises font_size/text/add/reorder)
- [x] Hash round-trips through SQLite (\`default_elements_hash_roundtrips_on_group\`)
- [x] Reset wipes user-added children (\`admin_reset_group_wipes_children_and_stamps_hash\` includes a hand-added child)
- [x] Reset rejects hand-built groups (\`admin_reset_group_rejects_handbuilt_group\`)
- [x] GET layout flags stale + non-stale groups (\`admin_get_layout_marks_stale_groups\`, \`admin_get_layout_marks_fresh_groups_not_stale\`)
- [ ] Manual: drop a plugin → save → edit manifest TOML → restart → reload admin → group shows "defaults updated" badge (8b will land the badge UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)