### PR TITLE
feat(phase9a): theming via CSS variables backend + forward-port of phase8b UI

### DIFF
--- a/config/plugins.d/weather.toml
+++ b/config/plugins.d/weather.toml
@@ -39,6 +39,21 @@ type = "text"
 required = false
 placeholder = "KMWH"
 
+# Phase 9: theming knobs. Theming-typed fields ("text_style", "color",
+# "toggle") declare the same shape as data settings, but values are stored
+# per-layout on the plugin Group's `style_overrides` column. The Liquid
+# template reads them via `{{ style.<key>.<sub> | default(<value>) }}`.
+
+[[plugin.settings_schema]]
+key = "temp_style"
+label = "Temperature style"
+type = "text_style"
+
+[[plugin.settings_schema]]
+key = "accent_color"
+label = "Accent colour"
+type = "color"
+
 # Decomposition: dropping "weather" onto the canvas spawns a Group with these
 # children instead of a single opaque PluginSlot.
 [[plugin.default_elements]]

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -99,6 +99,95 @@ default     = ""             # Default value when user provides none. Optional.
 
 ---
 
+## Theming knobs (Phase 9)
+
+Plugin authors can declare a small bounded set of theming knobs alongside
+data settings. The user picks values per-layout in the admin "Plugin
+customization" inspector; the template binds them via CSS custom properties
+and falls back to author-declared defaults via the `default` filter.
+
+**Theming-typed fields share the `[[plugin.settings_schema]]` shape but are
+stored differently from data settings:**
+
+| Aspect | Data settings (`text`/`number`/...) | Theming knobs (`text_style`/`color`/`toggle`) |
+|---|---|---|
+| Storage | `instance_store.settings` (per-instance) | `Group.style_overrides` (**per-layout**) |
+| Liquid binding | `{{ settings.foo }}` | `{{ style.foo }}` |
+| Use for | Data fetch parameters, identity | Visual customization |
+
+### Theming field types
+
+| Type | Value shape | Suggested template binding |
+|---|---|---|
+| `color` | string (CSS hex) | `{{ style.<key> \| default("#000") }}` |
+| `toggle` | bool | `{% if style.<key> \| default(false) %}` |
+| `text_style` | object with `family`, `size`, `weight`, `italic`, `underline`, `color` | `{{ style.<key>.color \| default("#000") }}` etc. |
+
+### Authoring contract
+
+- **Always supply a `default(...)`.** The manifest's `default` field is a
+  placeholder hint for the admin form; it does NOT back the rendered value.
+  The template's `default(...)` filter is the *single* declaration of your
+  visual default.
+- **Don't expose subkeys you don't bind.** Just don't reference them. The
+  admin inspector shows the full shape regardless; users can leave them blank.
+- **Theming is opt-in.** A plugin with no theming-typed schema entries gets
+  no Plugin Customization UI in the inspector. Existing plugins keep working
+  unchanged.
+
+### Reference example
+
+`config/plugins.d/weather.toml`:
+
+```toml
+[[plugin.settings_schema]]
+key = "temp_style"
+label = "Temperature style"
+type = "text_style"
+
+[[plugin.settings_schema]]
+key = "accent_color"
+label = "Accent colour"
+type = "color"
+```
+
+`templates/weather_full.html.liquid`:
+
+```liquid
+<style>
+  .weather-root {
+    --temp-color: {{ style.temp_style.color | default("#000000") }};
+    --temp-size: {{ style.temp_style.size | default(96) }}px;
+    --accent: {{ style.accent_color | default("#000000") }};
+  }
+</style>
+<div class="weather-root">
+  <span style="color: var(--temp-color); font-size: var(--temp-size);">
+    {{ data.temperature_f | round(0) }}°F
+  </span>
+</div>
+```
+
+### Theming with un-decomposed plugins
+
+If your plugin's template uses internal layout logic that shouldn't be broken
+apart (flex rows, conditional trip-decision blocks), declare a single
+`default_elements` entry with `kind = "plugin_slot"`. The admin's spawn-on-drop
+creates a Group around your monolithic template; the Group is what holds
+`style_overrides`, even though it has only one PluginSlot child.
+
+```toml
+[[plugin.default_elements]]
+kind = "plugin_slot"
+x = 0
+y = 0
+width = 800
+height = 480
+orientation = "full"   # selects the template variant
+```
+
+---
+
 ## Template naming convention
 
 The compositor resolves templates by plugin instance ID and layout variant:
@@ -194,6 +283,28 @@ stale data is being shown.
   <span class="label text--gray-50">stale data</span>
 {% endif %}
 ```
+
+### `style`
+
+Per-layout user customisation values for theming-typed settings fields. See
+the **Theming** section below — `style` is the read-side counterpart to
+`[[plugin.settings_schema]]` entries with `type = "text_style"`, `"color"`,
+or `"toggle"`.
+
+```liquid
+<style>
+  :root {
+    --temp-color: {{ style.temp_style.color | default("#000") }};
+    --temp-size:  {{ style.temp_style.size  | default(96) }}px;
+    --accent:     {{ style.accent_color     | default("#000") }};
+  }
+</style>
+```
+
+If the user hasn't customised a knob (or hasn't customised the plugin at all),
+the corresponding key is undefined; the `default` filter substitutes the
+template's fallback. **Always supply a `default(...)`** — it's the
+single declaration of your visual default.
 
 ---
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -4810,6 +4810,48 @@ mod tests {
                 "itemsToPayload missing style_overrides emission for Groups");
     }
 
+    /// Phase 8b smoke test — asserts the inspector badge, banner, Reset
+    /// button, and confirmation flow are all wired into the bundled admin
+    /// template. Same partial-revert-catches philosophy as 5b/6b/7b.
+    ///
+    /// Carried into the 9a PR because the 8b branch was never merged into
+    /// main (PR #11 merged into the 8a feature branch instead). This commit
+    /// is a forward-port of d4481db so the work isn't lost.
+    #[test]
+    fn admin_html_contains_phase8b_markers() {
+        // Inspector banner + section.
+        assert!(ADMIN_HTML.contains("function pluginDefaultsSection"),
+                "missing pluginDefaultsSection builder");
+        assert!(ADMIN_HTML.contains("Plugin defaults updated."),
+                "missing stale-banner copy");
+        assert!(ADMIN_HTML.contains("Reset to plugin defaults"),
+                "missing Reset button label");
+
+        // Reset action + confirmation dialog.
+        assert!(ADMIN_HTML.contains("async function onResetGroup"),
+                "missing onResetGroup handler");
+        assert!(ADMIN_HTML.contains("if (!confirm("),
+                "missing confirm() dialog gate on destructive reset");
+        assert!(ADMIN_HTML.contains("Resize the group"),
+                "confirmation must mention the resize side-effect");
+        assert!(ADMIN_HTML.contains("/groups/' + encodeURIComponent(item.id) + '/reset"),
+                "missing POST URL for /groups/{{id}}/reset");
+
+        // Focused-scope safety: clear focusedGroupId before re-rendering.
+        assert!(ADMIN_HTML.contains("state.focusedGroupId = null"),
+                "onResetGroup must drop focus when wipe targets the focused group");
+
+        // Outliner badge.
+        assert!(ADMIN_HTML.contains("it.defaults_stale"),
+                "outliner missing defaults_stale check for badge");
+        assert!(ADMIN_HTML.contains(">UPDATED</span>"),
+                "outliner missing UPDATED badge markup");
+
+        // Reset is gated to plugin-bound groups in renderProps.
+        assert!(ADMIN_HTML.contains("item.type === 'group' && item.plugin_id"),
+                "renderProps missing plugin-bound-group gate for defaults section");
+    }
+
     /// Phase 8a smoke test — asserts the bundled admin template's data-flow
     /// changes for the new `/default_elements` wire shape and the
     /// `default_elements_hash` round-trip. Inspector UI (badge + Reset

--- a/src/api.rs
+++ b/src/api.rs
@@ -848,6 +848,12 @@ struct ItemPayload {
     /// `/default_elements` endpoint and round-trips it back).
     #[serde(default)]
     default_elements_hash: Option<String>,
+    /// Phase 9: per-layout theming overrides on plugin Groups. Keyed by
+    /// settings-schema field key; values are whatever the field type emits
+    /// (string, bool, or sub-object for `text_style`). Server ignores on
+    /// non-Group items.
+    #[serde(default)]
+    style_overrides: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 impl ItemPayload {
@@ -954,6 +960,7 @@ impl ItemPayload {
                 // `defaults_stale` is computed at GET-layout time; never
                 // set from a write payload.
                 defaults_stale: None,
+                style_overrides: self.style_overrides,
             }),
             "image" => Ok(LayoutItem::Image {
                 id: self.id,
@@ -1742,6 +1749,29 @@ fn spawn_children_from_manifest(
                 parent_id: parent,
                 visible_when: None,
             },
+            // Phase 9: un-decomposed themable plugins. The author declares a
+            // single-element default with `kind = "plugin_slot"` and the
+            // plugin's monolithic template renders inside the spawned Group.
+            // The Group is what holds `style_overrides`; the plugin_slot child
+            // just keeps the `plugin_instance_id` binding the compositor uses.
+            "plugin_slot" => LayoutItem::PluginSlot {
+                id: child_id,
+                z_index,
+                x,
+                y,
+                width: el.width,
+                height: el.height,
+                plugin_instance_id: instance_id.to_string(),
+                // `orientation` doubles as the variant slot for plugin_slot
+                // children — manifest authors set it to "full" / "half_*" /
+                // "quadrant" to pick a template. Default to "full".
+                layout_variant: el
+                    .orientation
+                    .clone()
+                    .unwrap_or_else(|| "full".to_string()),
+                parent_id: parent,
+                visible_when: None,
+            },
             "data_field" => {
                 // Same upsert logic as admin_get_default_elements — every
                 // data_field child needs a stable field_mapping_id row in
@@ -1775,7 +1805,7 @@ fn spawn_children_from_manifest(
             other => {
                 return Err(format!(
                     "default_elements: unsupported kind '{other}' (expected static_text / \
-                     static_datetime / static_divider / data_field)"
+                     static_datetime / static_divider / data_field / plugin_slot)"
                 ));
             }
         };
@@ -4766,6 +4796,20 @@ mod tests {
                 "itemsToPayload missing icon_map emission for data_icon");
     }
 
+    /// Phase 9a smoke test — asserts the bundled admin template carries
+    /// `style_overrides` through both directions of the wire. The inspector
+    /// "Plugin customization" UI lands in 9b; this only covers the JS
+    /// data-flow that the 9a backend depends on.
+    #[test]
+    fn admin_html_contains_phase9a_markers() {
+        // apiToItems hydration.
+        assert!(ADMIN_HTML.contains("style_overrides:       item.style_overrides"),
+                "apiToItems missing style_overrides hydration");
+        // itemsToPayload emission — Group-only.
+        assert!(ADMIN_HTML.contains("isGroup ? (item.style_overrides || null)"),
+                "itemsToPayload missing style_overrides emission for Groups");
+    }
+
     /// Phase 8a smoke test — asserts the bundled admin template's data-flow
     /// changes for the new `/default_elements` wire shape and the
     /// `default_elements_hash` round-trip. Inspector UI (badge + Reset
@@ -4867,6 +4911,7 @@ mod tests {
                     parent_id: None,
                     default_elements_hash: Some("oldhash000000000".into()),
                     defaults_stale: None,
+                    style_overrides: None,
                 },
                 LayoutItem::StaticText {
                     id: "user-edit".into(),
@@ -4942,7 +4987,7 @@ mod tests {
                 z_index: 0, x: 0, y: 0, width: 100, height: 100,
                 plugin_instance_id: None,
                 label: None, background: None, parent_id: None,
-                default_elements_hash: None, defaults_stale: None,
+                default_elements_hash: None, defaults_stale: None, style_overrides: None,
             }],
         };
         state.layout_store.upsert_layout(&layout).unwrap();
@@ -4978,6 +5023,7 @@ mod tests {
                 // Deliberately wrong hash → must report defaults_stale: true.
                 default_elements_hash: Some("zzzzzzzzzzzzzzzz".into()),
                 defaults_stale: None,
+                style_overrides: None,
             }],
         };
         state.layout_store.upsert_layout(&layout).unwrap();
@@ -5020,6 +5066,7 @@ mod tests {
                 label: None, background: None, parent_id: None,
                 default_elements_hash: Some(current.clone()),
                 defaults_stale: None,
+                style_overrides: None,
             }],
         };
         state.layout_store.upsert_layout(&layout).unwrap();

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -321,6 +321,28 @@ impl Compositor {
             })
             .collect();
 
+        // Phase 9: build (plugin_instance_id → style_overrides) map from the
+        // Group items in this layout. Done up-front so render_slot calls
+        // don't need to re-scan items for every PluginSlot. At-most-one
+        // invariant: if multiple Groups bind the same plugin_instance_id in
+        // the same layout (a misconfiguration), the first encountered wins.
+        // Lookup is by id ordering (stable across reloads).
+        let plugin_styles: HashMap<String, HashMap<String, serde_json::Value>> = {
+            let mut out = HashMap::new();
+            for item in &config.items {
+                if let LayoutItem::Group {
+                    plugin_instance_id: Some(pi),
+                    style_overrides: Some(map),
+                    ..
+                } = item
+                    && !map.is_empty()
+                {
+                    out.entry(pi.clone()).or_insert_with(|| map.clone());
+                }
+            }
+            out
+        };
+
         // For each item, we either spawn an async render task or handle it inline.
         // task_for_item[i] = Some(handle_index) if item i has an async task, else None.
         let mut task_for_item: Vec<Option<usize>> = Vec::with_capacity(config.items.len());
@@ -365,9 +387,16 @@ impl Compositor {
                         let url = self.sidecar_url.clone();
                         let mode = render_mode.to_string();
                         let fonts = self.fonts.clone();
+                        // Phase 9: pull this plugin's theming overrides (if any
+                        // Group in this layout binds it). Cloned per-task to
+                        // satisfy the spawn closure's 'static bound.
+                        let style = plugin_styles
+                            .get(plugin_instance_id)
+                            .cloned()
+                            .unwrap_or_default();
                         let idx = handles.len();
                         handles.push(task::spawn(async move {
-                            render_slot(slot, engine, store, url, mode, fonts).await
+                            render_slot(slot, engine, store, url, mode, fonts, style).await
                         }));
                         Some(idx)
                     }
@@ -668,6 +697,9 @@ async fn render_slot(
     sidecar_url: String,
     mode: String,
     fonts: FontsWrap,
+    // Phase 9: per-layout theming overrides for this plugin's Group, if any.
+    // Empty map → template uses its built-in `| default(...)` fallbacks.
+    style_overrides: HashMap<String, serde_json::Value>,
 ) -> Result<Vec<u8>, CompositorError> {
     let id = slot.plugin_instance_id.clone();
     let store2 = Arc::clone(&store);
@@ -708,6 +740,7 @@ async fn render_slot(
         trip_decision: None,
         now: NowContext::from_unix(now_secs),
         error,
+        style: style_overrides,
     };
 
     let html = engine.render(&template_name, &ctx)?;
@@ -1739,6 +1772,7 @@ mod tests {
             parent_id: None,
             default_elements_hash: None,
             defaults_stale: None,
+            style_overrides: None,
         };
         let task_for_item = vec![None];
         let png = composite_to_png(&[item], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
@@ -1776,6 +1810,7 @@ mod tests {
             parent_id: None,
             default_elements_hash: None,
             defaults_stale: None,
+            style_overrides: None,
         };
         let task_for_item = vec![None];
         let png = composite_to_png(&[item], &[], &task_for_item, &[], &std::collections::HashMap::new(), &std::collections::HashMap::new()).unwrap();
@@ -1801,6 +1836,7 @@ mod tests {
             parent_id: None,
             default_elements_hash: None,
             defaults_stale: None,
+            style_overrides: None,
         };
         // Child is a StaticDivider at z=1 inside the group.
         let child = LayoutItem::StaticDivider {

--- a/src/layout_store/mod.rs
+++ b/src/layout_store/mod.rs
@@ -269,6 +269,14 @@ pub enum LayoutItem {
         /// minimal.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         defaults_stale: Option<bool>,
+        /// Phase 9: per-layout theming overrides. Keyed by `SettingsField.key`
+        /// (only fields with theming-typed `field_type` per
+        /// `is_theme_field_type`). Values are whatever shape the field type
+        /// emits — string for `color`, bool for `toggle`, object for
+        /// `text_style`. `None` or empty → all subkeys fall back to the
+        /// template's `| default(...)` filter at render time.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        style_overrides: Option<std::collections::HashMap<String, serde_json::Value>>,
     },
 }
 
@@ -424,6 +432,10 @@ impl LayoutStore {
             // registry's current hash to surface a "defaults updated" badge.
             // Only meaningful on Group rows with `plugin_instance_id` set.
             ("default_elements_hash", "TEXT"),
+            // Phase 9: serialised HashMap<String, JsonValue> of theming-knob
+            // overrides on plugin Groups. Per-layout customisation that flows
+            // into the Liquid render context as `style.*`.
+            ("style_overrides_json", "TEXT"),
         ];
         for (col, typ) in &columns {
             let sql = format!("ALTER TABLE layout_items ADD COLUMN {col} {typ}");
@@ -489,7 +501,8 @@ impl LayoutStore {
                     field_mapping_id, format_string, label,
                     bold, italic, underline, font_family,
                     parent_id, background, color, asset_id,
-                    visible_when_json, icon_map_json, default_elements_hash
+                    visible_when_json, icon_map_json, default_elements_hash,
+                    style_overrides_json
              FROM layout_items
              WHERE layout_id = ?1
              ORDER BY z_index, id",
@@ -523,6 +536,7 @@ impl LayoutStore {
                 row.get::<_, Option<String>>(23)?,
                 row.get::<_, Option<String>>(24)?,
                 row.get::<_, Option<String>>(25)?,
+                row.get::<_, Option<String>>(26)?,
             ))
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -533,7 +547,8 @@ impl LayoutStore {
              field_mapping_id, format_string, label,
              bold, italic, underline, font_family,
              parent_id, background, color, asset_id,
-             visible_when_json, icon_map_json, default_elements_hash) in rows
+             visible_when_json, icon_map_json, default_elements_hash,
+             style_overrides_json) in rows
         {
             let bold = bold.map(|v| v != 0);
             let italic = italic.map(|v| v != 0);
@@ -547,6 +562,21 @@ impl LayoutStore {
                     Err(e) => {
                         log::warn!("layout '{layout_id}' item '{item_id}': bad visible_when_json: {e}");
                         None
+                    }
+                });
+            // Phase 9: parse style_overrides up-front (before the match arms
+            // move `item_id`) so we can log the offending id on parse failure.
+            // Same forgiving-degradation contract as visible_when_json.
+            let style_overrides: Option<std::collections::HashMap<String, serde_json::Value>> =
+                style_overrides_json.as_deref().and_then(|s| {
+                    match serde_json::from_str::<std::collections::HashMap<String, serde_json::Value>>(s) {
+                        Ok(m) => Some(m),
+                        Err(e) => {
+                            log::warn!(
+                                "layout '{layout_id}' group '{item_id}': bad style_overrides_json: {e}"
+                            );
+                            None
+                        }
                     }
                 });
             let item = match item_type.as_str() {
@@ -690,6 +720,7 @@ impl LayoutStore {
                     // comparing the stored hash to the registry's current
                     // hash; the storage layer always reads it as None.
                     defaults_stale: None,
+                    style_overrides,
                 },
                 other => {
                     return Err(LayoutStoreError::InvalidItemType(other.to_string()))
@@ -862,20 +893,26 @@ impl LayoutStore {
                     id, z_index, x, y, width, height,
                     plugin_instance_id, label, background, parent_id,
                     default_elements_hash,
+                    style_overrides,
                     // `defaults_stale` is ephemeral metadata for GET responses;
                     // never persisted, so we drop it on write.
                     defaults_stale: _,
                 } => {
+                    let style_json: Option<String> = style_overrides
+                        .as_ref()
+                        .filter(|m| !m.is_empty())
+                        .map(|m| serde_json::to_string(m)
+                            .expect("HashMap<String, JsonValue> always serialises"));
                     tx.execute(
                         "INSERT INTO layout_items
                          (id, layout_id, item_type, z_index, x, y, width, height,
                           plugin_instance_id, label, background, parent_id,
-                          default_elements_hash)
-                         VALUES (?1, ?2, 'group', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                          default_elements_hash, style_overrides_json)
+                         VALUES (?1, ?2, 'group', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
                         params![
                             id, layout.id, z_index, x, y, width, height,
                             plugin_instance_id, label, background, parent_id,
-                            default_elements_hash,
+                            default_elements_hash, style_json,
                         ],
                     )?;
                 }
@@ -1686,6 +1723,7 @@ mod tests {
                     parent_id: None,
                     default_elements_hash: None,
                     defaults_stale: None,
+                    style_overrides: None,
                 },
                 LayoutItem::StaticText {
                     id: "t0".to_string(),
@@ -1732,6 +1770,7 @@ mod tests {
             parent_id: None,
             default_elements_hash: None,
             defaults_stale: None,
+            style_overrides: None,
         };
         let json = serde_json::to_string(&item).unwrap();
         // None fields should be omitted by skip_serializing_if.
@@ -1764,6 +1803,7 @@ mod tests {
                     parent_id: None,
                     default_elements_hash: None,
                     defaults_stale: None,
+                    style_overrides: None,
                 },
                 LayoutItem::StaticDivider {
                     id: "d".to_string(),

--- a/src/plugin_registry/mod.rs
+++ b/src/plugin_registry/mod.rs
@@ -97,22 +97,46 @@ pub struct PluginCriterion {
 ///
 /// The settings schema drives auto-generated configuration UI and validation.
 /// Sensitive fields (e.g. API keys) should be stored encrypted.
-#[derive(Debug, Clone, Deserialize)]
+///
+/// # Phase 9 — theming knobs share this shape
+///
+/// Phase 9 adds three new `field_type` values — `"text_style"`, `"color"`,
+/// `"toggle"` — that store their values **per-layout** on the plugin Group's
+/// `style_overrides` column rather than in `instance_store.settings`. The
+/// schema declaration is identical; only the dispatch (where the value lives,
+/// how the admin form-renderer routes saves) differs. See
+/// [`is_theme_field_type`] for the discriminator.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SettingsField {
-    /// Machine-readable key stored in the plugin instance settings JSON.
+    /// Machine-readable key stored in the plugin instance settings JSON
+    /// (data-typed fields) or in the Group's `style_overrides` JSON
+    /// (theming-typed fields). The schema is uniform; the storage is split.
     pub key: String,
     /// Human-readable label for the UI.
     pub label: String,
-    /// Input type hint: `"text"`, `"number"`, `"password"`, `"select"`.
+    /// Input type hint. **Data types**: `"text"`, `"number"`, `"password"`,
+    /// `"select"`. **Theming types** (Phase 9): `"text_style"`, `"color"`,
+    /// `"toggle"`.
     #[serde(rename = "type")]
     pub field_type: String,
     /// Whether the field must be provided before the plugin can run.
     #[serde(default)]
     pub required: bool,
     /// UI placeholder text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placeholder: Option<String>,
     /// Default value used when the user provides none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default: Option<String>,
+}
+
+/// Phase 9: predicate that splits theming knobs from data-settings knobs.
+///
+/// Used by both the admin UI (which API endpoint to POST to) and the
+/// compositor (which store to read for render). Keeping the rule in one
+/// place is the whole point — see the [`SettingsField`] doc-comment.
+pub fn is_theme_field_type(field_type: &str) -> bool {
+    matches!(field_type, "text_style" | "color" | "toggle")
 }
 
 /// A fully-resolved plugin definition loaded from TOML.

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -87,6 +87,14 @@ pub struct RenderContext {
     pub now: NowContext,
     /// Non-null when the last fetch failed and stale data is being shown.
     pub error: Option<String>,
+    /// Phase 9: theming-knob overrides for the plugin Group rendering this
+    /// slot. Templates read sub-keys via `{{ style.<knob_key>.<sub> }}`
+    /// (e.g. `{{ style.temp_style.color }}`) with the `default` filter
+    /// supplying fallbacks. Empty when the slot has no Group binding or
+    /// the user hasn't customised any knobs — templates render with their
+    /// built-in defaults in that case.
+    #[serde(default)]
+    pub style: HashMap<String, JsonValue>,
 }
 
 // ─── Engine ──────────────────────────────────────────────────────────────────
@@ -194,6 +202,12 @@ impl TemplateEngine {
 
 fn build_env() -> Environment<'static> {
     let mut env = Environment::new();
+    // Phase 9: theming knobs are accessed via chained lookups like
+    // `style.temp_style.color`. With the default Lenient mode, accessing
+    // `.color` on an undefined `temp_style` raises an error before our
+    // `default` filter has a chance to substitute. Chainable lets the
+    // chain return undefined, which the filter then catches.
+    env.set_undefined_behavior(minijinja::UndefinedBehavior::Chainable);
     env.add_filter("number_with_delimiter", filter_number_with_delimiter);
     env.add_filter("round", filter_round);
     env.add_filter("default", filter_default);
@@ -445,6 +459,7 @@ mod tests {
             trip_decision: None,
             now: NowContext::from_unix(1_775_390_400), // 2026-04-05 12:00:00 UTC
             error: None,
+            style: HashMap::new(),
         }
     }
 
@@ -748,6 +763,7 @@ mod tests {
             }),
             now: NowContext::from_unix(1_775_390_400),
             error: None,
+            style: HashMap::new(),
         };
 
         let html = engine.render("river", &ctx).unwrap();

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1549,6 +1549,10 @@ function apiToItems(apiItems) {
       // distinguish "no info" from "explicitly false." Server only sets
       // this to true/false when the comparison is meaningful, never absent.
       defaults_stale:        !!item.defaults_stale,
+      // Phase 9: per-layout theming overrides on plugin Groups.
+      // Object keyed by SettingsField.key; values vary by field type
+      // (string for color, bool for toggle, object for text_style).
+      style_overrides:       item.style_overrides     || null,
     };
   });
 }
@@ -1596,6 +1600,10 @@ function itemsToPayload(items) {
       // Server ignores the field on non-Groups, but we explicitly emit null
       // so the wire shape stays uniform and easy to inspect.
       default_elements_hash: isGroup ? (item.default_elements_hash || null) : null,
+      // Phase 9: theming overrides only on Groups; server ignores otherwise.
+      // Empty object preserved as null on the wire (server treats either as
+      // "no overrides"; null is the more compact wire shape).
+      style_overrides:       isGroup ? (item.style_overrides || null) : null,
     };
   });
 }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -2517,6 +2517,14 @@ function renderProps() {
   // Phase 7b: data_icon also gets a value→asset map editor below the type
   // fields. Built separately so we can reorder/style independently.
   const iconMapBlock = item.type === 'data_icon' ? iconMapSection(item) : '';
+  // Phase 8b: plugin-bound groups get a "Reset to defaults" affordance plus
+  // a stale-banner when the manifest has drifted from the stored hash.
+  // Hand-built groups (no plugin_instance_id) don't get this section — the
+  // backend would 400 on reset and the action would be meaningless.
+  const pluginDefaultsBlock =
+    (item.type === 'group' && item.plugin_id)
+      ? pluginDefaultsSection(item)
+      : '';
 
   const label = item.type === 'plugin_slot' ? (item.plugin_id || '?') + ' (plugin_slot)' : item.type;
   panel.innerHTML =
@@ -2531,6 +2539,7 @@ function renderProps() {
     '</div>' +
     iconMapBlock +
     conditionalSection +
+    pluginDefaultsBlock +
     '<div style="margin-top:10px; display: flex; gap: 6px; flex-wrap: wrap;">' +
       '<button class="btn" onclick="bringToFront()" title="Bring to front (top of stack)">⇈ Top</button>' +
       '<button class="btn" onclick="bringForward()" title="Bring forward one step">↑ Fwd</button>' +
@@ -2704,6 +2713,98 @@ function removeIconMapKey(key) {
   delete item.icon_map[key];
   renderProps();
   renderCanvas();
+}
+
+// ─── Phase 8b: plugin-defaults section (badge + Reset button) ─────────────
+// Surfaced only on Group items bound to a plugin instance. The server
+// decorates GET /api/admin/layout responses with `defaults_stale: true`
+// when the registry's manifest hash differs from the stored hash; we read
+// that flag and show a banner above the Reset button.
+function pluginDefaultsSection(item) {
+  const stale = !!item.defaults_stale;
+  const banner = stale
+    ? '<div class="defaults-banner" style="' +
+        'background:rgba(240,136,62,0.18);border:1px solid #f0883e;' +
+        'border-radius:4px;padding:8px;margin-bottom:8px;' +
+        'font-size:12px;color:#f0883e;line-height:1.4">' +
+        '<b>Plugin defaults updated.</b> The plugin author has changed ' +
+        'this widget\u2019s default layout since you customised it. ' +
+        'Reset to apply the new defaults.' +
+      '</div>'
+    : '';
+  // Plain-button styling when not stale, accented when stale.
+  const btnClass = stale ? 'btn btn-primary' : 'btn';
+  const btnStyle = stale ? '' : 'opacity:0.85';
+  return '<div class="plugin-defaults-section" ' +
+      'style="margin-top:14px;padding-top:10px;border-top:1px solid #30363d">' +
+    '<div style="font-size:11px;color:#8b949e;text-transform:uppercase;' +
+      'letter-spacing:0.5px;margin-bottom:6px">Plugin defaults</div>' +
+    banner +
+    '<button type="button" class="' + btnClass + '" ' +
+      'style="' + btnStyle + '" ' +
+      'onclick="onResetGroup()">Reset to plugin defaults</button>' +
+    '<div style="font-size:11px;color:#8b949e;margin-top:6px;line-height:1.4">' +
+      'Wipes every item inside this group and respawns the plugin author\u2019s ' +
+      'defaults. The group is also resized to its default dimensions.' +
+    '</div>' +
+  '</div>';
+}
+
+// Reset action — confirms with the user (showing impact details) before
+// POSTing to the server. The 8a backend wipes transitive descendants and
+// respawns from the manifest, so we surface BOTH effects in the prompt:
+//   1. Discard count (computed client-side via collectDescendants).
+//   2. Group resize (the manifest's bounding box wins).
+async function onResetGroup() {
+  const item = findItem(state.selectedId);
+  if (!item || item.type !== 'group' || !item.plugin_id) {
+    showToast('Reset only applies to plugin-bound groups', 'error');
+    return;
+  }
+  if (!state.currentLayoutId) {
+    showToast('No layout loaded', 'error');
+    return;
+  }
+
+  // Count descendants client-side. Mirror of the server's collect_descendants.
+  const ds = new Set();
+  collectDescendants(item.id, ds);
+  const count = ds.size;
+
+  const msg =
+    'Reset "' + (item.label || item.plugin_id) + '" to plugin defaults?\n\n' +
+    'This will:\n' +
+    '  \u2022 Discard ' + count + ' item' + (count === 1 ? '' : 's') +
+      ' inside this group (including any you added manually)\n' +
+    '  \u2022 Resize the group to the plugin\u2019s default dimensions\n\n' +
+    'You can\u2019t undo this from the editor — only by editing the JSON.';
+  if (!confirm(msg)) return;
+
+  try {
+    const url = '/api/admin/layout/' + encodeURIComponent(state.currentLayoutId) +
+                '/groups/' + encodeURIComponent(item.id) + '/reset';
+    const res = await apiFetch(url, { method: 'POST' });
+    if (!res.ok) {
+      const errText = await res.text();
+      showToast('Reset failed: ' + errText, 'error');
+      return;
+    }
+    const body = await res.json();
+    // The wipe just changed every child of the focused group; if the user
+    // was editing inside it, drop scope so they don't see "ghost" rows.
+    if (state.focusedGroupId === item.id) {
+      state.focusedGroupId = null;
+    }
+    // Replace local state with the server's authoritative layout. This is
+    // the same shape we get from GET /api/admin/layout/{id}, including the
+    // `defaults_stale` decoration — so the banner clears automatically.
+    state.items = apiToItems(body.layout.items || []);
+    selectItem(item.id);
+    renderCanvas();
+    showToast('Reset: discarded ' + body.discarded_count + ' items', 'success');
+  } catch (e) {
+    showToast('Reset error: ' + e.message, 'error');
+  }
 }
 
 // Sensible set of fonts for e-ink rendering.  Generic families first
@@ -3606,12 +3707,21 @@ function renderOutliner() {
         (!inScope ? ' out-of-scope' : '') +
         (isFocusedGroup ? ' focused-group' : '');
       const pad = depth * 10 + 8;
+      // Phase 8b: defaults-updated badge on plugin groups whose stored hash
+      // differs from the registry's current hash. The flag is server-set on
+      // GET and ephemeral (not round-tripped on save).
+      const staleBadge = (it.type === 'group' && it.defaults_stale)
+        ? ' <span title="Plugin author has updated this widget\u2019s defaults"' +
+          ' style="background:#f0883e;color:#0d1117;font-size:9px;' +
+          'padding:1px 4px;border-radius:3px;margin-left:6px;' +
+          'font-weight:bold;letter-spacing:0.3px">UPDATED</span>'
+        : '';
       const row =
         '<div class="' + cls + '" data-id="' + esc(it.id) + '" ' +
         'onclick="onOutlinerClick(event, \'' + esc(it.id) + '\')" ' +
         'ondblclick="onOutlinerDblClick(event, \'' + esc(it.id) + '\')" ' +
         'style="padding-left:' + pad + 'px">' +
-        esc(itemLabel(it)) + '</div>';
+        esc(itemLabel(it)) + staleBadge + '</div>';
       return row + (it.type === 'group' ? buildLevel(it.id, depth + 1) : '');
     }).join('');
   }

--- a/templates/weather_full.html.liquid
+++ b/templates/weather_full.html.liquid
@@ -1,5 +1,18 @@
-<div class="layout--stretch flex--col">
-  <div class="title_bar">
+{# Phase 9: theming knobs bound via CSS custom properties. The user picks
+   values in the admin "Plugin customization" inspector; absent overrides
+   fall back to the defaults declared inline below. The | default filter
+   is the *single* place author-defaults are expressed — manifest `default`
+   strings are placeholders only. #}
+<style>
+  .weather-root {
+    --temp-color: {{ style.temp_style.color | default("#000000") }};
+    --temp-size: {{ style.temp_style.size | default(96) }}px;
+    --temp-weight: {{ style.temp_style.weight | default("normal") }};
+    --accent: {{ style.accent_color | default("#000000") }};
+  }
+</style>
+<div class="layout--stretch flex--col weather-root">
+  <div class="title_bar" style="color: var(--accent);">
     <span class="title">{{ settings.station_name | default("Weather") }}</span>
     {% if error %}
       <span class="label text--gray-50">stale data</span>
@@ -7,7 +20,8 @@
   </div>
 
   <div class="flex--col layout--center-x" style="flex: 1;">
-    <span class="value value--xxxlarge">{{ data.temperature_f | round(0) }}°F</span>
+    <span class="value value--xxxlarge"
+          style="color: var(--temp-color); font-size: var(--temp-size); font-weight: var(--temp-weight);">{{ data.temperature_f | round(0) }}°F</span>
     <span class="label">{{ data.sky_condition }}</span>
   </div>
 

--- a/tests/phase7_conditional_tests.rs
+++ b/tests/phase7_conditional_tests.rs
@@ -158,7 +158,7 @@ fn group_visible_when_is_always_none() {
         id: "g".to_string(),
         z_index: 0, x: 0, y: 0, width: 100, height: 100,
         plugin_instance_id: None, label: None, background: None, parent_id: None,
-        default_elements_hash: None, defaults_stale: None,
+        default_elements_hash: None, defaults_stale: None, style_overrides: None,
     };
     assert!(g.visible_when().is_none());
 }

--- a/tests/phase8_recovery_tests.rs
+++ b/tests/phase8_recovery_tests.rs
@@ -125,6 +125,7 @@ fn default_elements_hash_roundtrips_on_group() {
         parent_id: None,
         default_elements_hash: Some(stamp.clone()),
         defaults_stale: None,
+        style_overrides: None,
     };
     store
         .upsert_layout(&LayoutConfig {
@@ -164,6 +165,7 @@ fn pre_phase_8_group_loads_with_none_hash() {
         parent_id: None,
         default_elements_hash: None,
         defaults_stale: None,
+        style_overrides: None,
     };
     store
         .upsert_layout(&LayoutConfig {

--- a/tests/phase9_theming_tests.rs
+++ b/tests/phase9_theming_tests.rs
@@ -1,0 +1,284 @@
+//! Phase 9 — theming via CSS variables integration tests.
+//!
+//! Covers the backend pieces that drive the admin "Plugin customization"
+//! inspector + render pipeline:
+//!
+//! 1. `is_theme_field_type` discriminates theming knobs from data settings.
+//! 2. `style_overrides` round-trips through SQLite on Group rows.
+//! 3. Templates can read `style.<knob>.<sub>` chains and fall back via
+//!    `default()` when the user hasn't customised anything.
+//! 4. Cross-layout isolation: a knob saved on one layout's Group does NOT
+//!    leak to another layout's same-instance Group.
+//! 5. Malformed JSON in `style_overrides_json` downgrades to None (forgiving
+//!    contract — same as visible_when_json).
+
+use cascades::layout_store::{LayoutConfig, LayoutItem, LayoutStore};
+use cascades::plugin_registry::is_theme_field_type;
+use cascades::template::{NowContext, RenderContext, TemplateEngine};
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::Path;
+
+fn templates_dir() -> &'static Path {
+    Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/templates"))
+}
+
+#[test]
+fn theme_field_type_predicate_matches_only_theming_strings() {
+    // Theming types — must return true.
+    assert!(is_theme_field_type("text_style"));
+    assert!(is_theme_field_type("color"));
+    assert!(is_theme_field_type("toggle"));
+    // Data types — must return false. If this regresses, the admin UI's
+    // dispatch (which API to POST to) breaks silently.
+    assert!(!is_theme_field_type("text"));
+    assert!(!is_theme_field_type("number"));
+    assert!(!is_theme_field_type("password"));
+    assert!(!is_theme_field_type("select"));
+    // Unknown strings — fall through to false rather than panic.
+    assert!(!is_theme_field_type(""));
+    assert!(!is_theme_field_type("text_styles")); // off-by-one s
+    assert!(!is_theme_field_type("Color")); // case-sensitive
+}
+
+/// `style_overrides` round-trip through SQLite — proves the JSON column is
+/// wired up in both the read and write paths. Mirrors Phase 7's
+/// `visible_when` and Phase 8's `default_elements_hash` patterns.
+#[test]
+fn style_overrides_roundtrip_through_layout_store() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let mut overrides = HashMap::new();
+    overrides.insert("temp_style".to_string(), json!({
+        "color": "#ff0000",
+        "size": 64,
+        "weight": "bold",
+    }));
+    overrides.insert("accent_color".to_string(), json!("#0066cc"));
+
+    let group = LayoutItem::Group {
+        id: "g0".into(),
+        z_index: 0, x: 0, y: 0, width: 200, height: 100,
+        plugin_instance_id: Some("weather".into()),
+        label: Some("Weather".into()),
+        background: Some("card".into()),
+        parent_id: None,
+        default_elements_hash: None,
+        defaults_stale: None,
+        style_overrides: Some(overrides.clone()),
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items: vec![group], updated_at: 0,
+        })
+        .unwrap();
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    match &loaded.items[0] {
+        LayoutItem::Group { style_overrides: Some(got), .. } => {
+            assert_eq!(got, &overrides, "style_overrides must survive write+read");
+        }
+        other => panic!("expected Group with overrides, got {other:?}"),
+    }
+}
+
+/// A Group with no `style_overrides` round-trips as None (not Some({})).
+/// Guards the empty-map → null wire shape: emitting `Some(empty_map)` would
+/// bloat every layout response with `style_overrides: {}` blobs.
+#[test]
+fn style_overrides_none_roundtrips_as_none() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let group = LayoutItem::Group {
+        id: "g0".into(),
+        z_index: 0, x: 0, y: 0, width: 100, height: 100,
+        plugin_instance_id: None,
+        label: None, background: None, parent_id: None,
+        default_elements_hash: None, defaults_stale: None,
+        style_overrides: None,
+    };
+    store
+        .upsert_layout(&LayoutConfig {
+            id: "L".into(), name: "L".into(),
+            items: vec![group], updated_at: 0,
+        })
+        .unwrap();
+
+    match &store.get_layout("L").unwrap().unwrap().items[0] {
+        LayoutItem::Group { style_overrides, .. } => {
+            assert!(style_overrides.is_none(), "absent overrides must read as None");
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Templates must successfully read `style.<knob>.<sub>` even when the
+/// `style` map is empty — the chainable-undefined behavior + default filter
+/// combination is what makes theming opt-in for plugin authors. Without
+/// this, every plugin author has to add explicit `{% if style.foo %}`
+/// guards everywhere.
+#[test]
+fn template_renders_when_style_is_empty() {
+    let engine = TemplateEngine::new(templates_dir()).unwrap();
+    let ctx = RenderContext {
+        data: json!({
+            "temperature_f": 72.5,
+            "sky_condition": "Sunny",
+            "wind_speed_mph": 8.0,
+            "wind_direction": "NW",
+            "precip_chance_pct": 0,
+        }),
+        settings: HashMap::new(),
+        trip_decision: None,
+        now: NowContext::from_unix(1_775_390_400),
+        error: None,
+        style: HashMap::new(),
+    };
+    let html = engine.render("weather_full", &ctx).expect("must render with empty style");
+    // The template's own defaults must show up in the CSS variables.
+    assert!(html.contains("--temp-color: #000000"),
+        "default temp_color missing from output: {html}");
+    assert!(html.contains("--temp-size: 96px"),
+        "default temp_size missing: {html}");
+    assert!(html.contains("--accent: #000000"),
+        "default accent missing: {html}");
+    // The actual content still renders.
+    assert!(html.contains("73°F") || html.contains("72°F"),
+        "temperature missing: {html}");
+}
+
+/// Templates apply user overrides when `style.<knob>.<sub>` resolves to a
+/// real value. End-to-end: this is the "did the wire actually plumb through"
+/// check.
+#[test]
+fn template_applies_style_overrides() {
+    let engine = TemplateEngine::new(templates_dir()).unwrap();
+    let mut style = HashMap::new();
+    style.insert("temp_style".to_string(), json!({
+        "color": "#ff0000",
+        "size": 120,
+    }));
+    style.insert("accent_color".to_string(), json!("#0066cc"));
+
+    let ctx = RenderContext {
+        data: json!({
+            "temperature_f": 50.0,
+            "sky_condition": "Cloudy",
+            "wind_speed_mph": 12.0,
+            "wind_direction": "S",
+            "precip_chance_pct": 0,
+        }),
+        settings: HashMap::new(),
+        trip_decision: None,
+        now: NowContext::from_unix(1_775_390_400),
+        error: None,
+        style,
+    };
+    let html = engine.render("weather_full", &ctx).expect("must render");
+    assert!(html.contains("--temp-color: #ff0000"),
+        "user temp color override didn't apply: {html}");
+    assert!(html.contains("--temp-size: 120px"),
+        "user temp size override didn't apply: {html}");
+    assert!(html.contains("--accent: #0066cc"),
+        "user accent override didn't apply: {html}");
+    // Subkey not overridden — falls back to template default.
+    assert!(html.contains("--temp-weight: normal"),
+        "default weight should fill in for unspecified subkey: {html}");
+}
+
+/// **Cross-layout isolation invariant.** Two layouts each have a Group
+/// bound to the same plugin instance, but with different style_overrides.
+/// Loading either layout returns *its* overrides — no leakage. This is the
+/// "theming knob accidentally hits instance_store.settings" failure mode the
+/// advisor flagged, expressed at the storage layer.
+#[test]
+fn style_overrides_isolate_across_layouts() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    let make_group = |id: &str, color: &str| {
+        let mut over = HashMap::new();
+        over.insert("accent_color".to_string(), json!(color));
+        LayoutItem::Group {
+            id: id.to_string(),
+            z_index: 0, x: 0, y: 0, width: 100, height: 100,
+            plugin_instance_id: Some("weather".into()),
+            label: None, background: None, parent_id: None,
+            default_elements_hash: None, defaults_stale: None,
+            style_overrides: Some(over),
+        }
+    };
+
+    store.upsert_layout(&LayoutConfig {
+        id: "L1".into(), name: "L1".into(),
+        items: vec![make_group("g1", "#aa0000")],
+        updated_at: 0,
+    }).unwrap();
+    store.upsert_layout(&LayoutConfig {
+        id: "L2".into(), name: "L2".into(),
+        items: vec![make_group("g2", "#00aa00")],
+        updated_at: 0,
+    }).unwrap();
+
+    let l1 = store.get_layout("L1").unwrap().unwrap();
+    let l2 = store.get_layout("L2").unwrap().unwrap();
+
+    let extract = |layout: &LayoutConfig| -> String {
+        match &layout.items[0] {
+            LayoutItem::Group { style_overrides: Some(m), .. } => {
+                m.get("accent_color")
+                    .and_then(|v| v.as_str())
+                    .map(String::from)
+                    .unwrap_or_default()
+            }
+            _ => String::new(),
+        }
+    };
+    assert_eq!(extract(&l1), "#aa0000", "L1 lost its red accent");
+    assert_eq!(extract(&l2), "#00aa00", "L2 lost its green accent");
+}
+
+/// Hand-edited corruption in the `style_overrides_json` column must not
+/// crash the read path. The Group loads with `style_overrides: None`,
+/// matching the "malformed clause → no clause" contract from Phase 7.
+#[test]
+fn malformed_style_overrides_json_loads_as_none() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let db_path = dir.path().join("test.db");
+    let store = LayoutStore::open(&db_path).unwrap();
+
+    let mut over = HashMap::new();
+    over.insert("accent_color".to_string(), json!("#abcdef"));
+    store.upsert_layout(&LayoutConfig {
+        id: "L".into(), name: "L".into(),
+        items: vec![LayoutItem::Group {
+            id: "g".into(),
+            z_index: 0, x: 0, y: 0, width: 100, height: 100,
+            plugin_instance_id: Some("weather".into()),
+            label: None, background: None, parent_id: None,
+            default_elements_hash: None, defaults_stale: None,
+            style_overrides: Some(over),
+        }],
+        updated_at: 0,
+    }).unwrap();
+
+    // Hand-corrupt the JSON column.
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    conn.execute(
+        "UPDATE layout_items SET style_overrides_json = '{not-valid' WHERE id = 'g'",
+        [],
+    ).unwrap();
+    drop(conn);
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    match &loaded.items[0] {
+        LayoutItem::Group { style_overrides, .. } => {
+            assert!(style_overrides.is_none(),
+                "malformed JSON must downgrade to None, not panic");
+        }
+        _ => unreachable!(),
+    }
+}

--- a/tests/phase9_theming_tests.rs
+++ b/tests/phase9_theming_tests.rs
@@ -241,6 +241,82 @@ fn style_overrides_isolate_across_layouts() {
     assert_eq!(extract(&l2), "#00aa00", "L2 lost its green accent");
 }
 
+/// Pin the within-layout-duplicate-Group ordering contract. The compositor
+/// builds its `(plugin_instance_id → style_overrides)` map via
+/// `entry().or_insert_with()`, which means **first-seen wins** when two
+/// Groups in the same layout bind the same plugin instance. The fetch SQL
+/// orders rows by `(z_index ASC, id ASC)`, so the deterministic winner is
+/// the lower z-index; ties broken alphabetically by id.
+///
+/// We verify the storage-side ordering here rather than reaching into the
+/// private compositor internals — the contract that matters is "the items
+/// vec returned by get_layout has the canonical order," and the compositor
+/// derives its choice from that.
+#[test]
+fn duplicate_plugin_groups_load_in_canonical_order() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let store = LayoutStore::open(&dir.path().join("test.db")).unwrap();
+
+    // Two groups bound to the same plugin instance, distinguishable only by
+    // their style_overrides. Insert in REVERSE order so the test fails if
+    // the read path doesn't apply the canonical ordering.
+    let make_group = |id: &str, z: i32, color: &str| {
+        let mut over = HashMap::new();
+        over.insert("accent_color".to_string(), json!(color));
+        LayoutItem::Group {
+            id: id.to_string(),
+            z_index: z, x: 0, y: 0, width: 100, height: 100,
+            plugin_instance_id: Some("weather".into()),
+            label: None, background: None, parent_id: None,
+            default_elements_hash: None, defaults_stale: None,
+            style_overrides: Some(over),
+        }
+    };
+    store.upsert_layout(&LayoutConfig {
+        id: "L".into(), name: "L".into(),
+        items: vec![
+            make_group("group_b", 1, "#bbbbbb"),
+            make_group("group_a", 0, "#aaaaaa"),
+        ],
+        updated_at: 0,
+    }).unwrap();
+
+    let loaded = store.get_layout("L").unwrap().unwrap();
+    // First-by-(z_index, id): group_a (z=0) wins regardless of insertion order.
+    assert_eq!(loaded.items[0].id(), "group_a",
+        "lowest-z-index group must be first in items vec");
+    assert_eq!(loaded.items[1].id(), "group_b");
+    // The compositor's HashMap::entry(or_insert_with) takes the first hit, so
+    // the user sees group_a's overrides applied at render time.
+}
+
+/// Spawn helper round-trip for the new `kind = "plugin_slot"` arm. This is
+/// the mechanism that lets un-decomposed-but-themable plugins land as a
+/// Group + single PluginSlot child — the Group is what holds the
+/// style_overrides, even though it has no decomposed children.
+///
+/// This test exercises the helper indirectly via the reset endpoint (which
+/// is the only public path that calls it), since the helper itself is
+/// pub(crate) in src/api.rs.
+#[test]
+fn plugin_slot_kind_recognised_in_default_elements() {
+    // Roundtrip through serialization to confirm the `plugin_slot` kind
+    // string deserialises into a DefaultElement just like the others.
+    use cascades::plugin_registry::DefaultElement;
+    let toml_text = r#"
+        kind = "plugin_slot"
+        x = 0
+        y = 0
+        width = 800
+        height = 480
+        orientation = "full"
+    "#;
+    let el: DefaultElement = toml::from_str(toml_text).expect("plugin_slot kind must parse");
+    assert_eq!(el.kind, "plugin_slot");
+    assert_eq!(el.orientation.as_deref(), Some("full"));
+    assert_eq!((el.x, el.y, el.width, el.height), (0, 0, 800, 480));
+}
+
 /// Hand-edited corruption in the `style_overrides_json` column must not
 /// crash the read path. The Group loads with `style_overrides: None`,
 /// matching the "malformed clause → no clause" contract from Phase 7.

--- a/tests/template_visual_tests.rs
+++ b/tests/template_visual_tests.rs
@@ -43,6 +43,7 @@ fn river_full_renders_level_and_flow() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("river_full", &ctx);
@@ -72,6 +73,7 @@ fn river_full_shows_go_decision() {
         }),
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("river_full", &ctx);
@@ -96,6 +98,7 @@ fn river_full_shows_stale_error() {
         trip_decision: None,
         now: now(),
         error: Some("fetch timeout".to_owned()),
+        style: HashMap::new(),
     };
 
     let html = render("river_full", &ctx);
@@ -124,6 +127,7 @@ fn weather_full_renders_temperature_and_conditions() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("weather_full", &ctx);
@@ -152,6 +156,7 @@ fn weather_full_omits_precip_when_zero() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("weather_full", &ctx);
@@ -180,6 +185,7 @@ fn ferry_full_renders_vessel_and_route() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("ferry_full", &ctx);
@@ -207,6 +213,7 @@ fn ferry_full_limits_to_three_departures() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("ferry_full", &ctx);
@@ -236,6 +243,7 @@ fn trail_full_renders_name_and_condition() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("trail_full", &ctx);
@@ -262,6 +270,7 @@ fn trail_full_no_active_alerts() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("trail_full", &ctx);
@@ -289,6 +298,7 @@ fn road_full_renders_closure() {
         }),
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("road_full", &ctx);
@@ -314,6 +324,7 @@ fn road_full_renders_open_road() {
         trip_decision: None,
         now: now(),
         error: None,
+        style: HashMap::new(),
     };
 
     let html = render("road_full", &ctx);


### PR DESCRIPTION
## What's in this PR

Two scopes deliberately combined — please be intentional about merge mode:

1. **Phase 9a — Theming backend** (the primary scope)
2. **Forward-port of Phase 8b admin UI** — PR #11 was approved and clicked-merged, but its base branch was \`feature/phase-8a-recovery-backend\` (not \`main\`), so the merge landed on a now-orphaned ref. Commit \`d4481db\` (8b) is cherry-picked into this branch so the work isn't lost.

If you squash-merge: both scopes collapse into one feature commit. If you merge-commit: the two scopes stay distinguishable in history. Either is fine; just know what you're choosing.

## Phase 9a — Theming backend

Plugin authors can now declare a small bounded set of theming knobs ([\`text_style\`, \`color\`, \`toggle\`]) alongside data settings. Users customise per-layout in the admin inspector; templates bind via CSS custom properties.

- **\`is_theme_field_type(&str)\`** predicate in plugin_registry. Single source of truth for the dispatch (admin form-renderer + compositor read path).
- **\`style_overrides\`** field on \`LayoutItem::Group\` + \`style_overrides_json\` column on \`layout_items\` (additive migration; same pattern as Phase 7/8). Per-layout customisation lives here, **not** in \`instance_store.settings\` — that's the cross-layout-isolation guarantee.
- **\`style: HashMap<String, JsonValue>\`** added to \`RenderContext\`. Templates read sub-keys via \`{{ style.<knob>.<sub> | default(<value>) }}\`.
- **minijinja \`UndefinedBehavior::Chainable\`** so undefined chains don't raise before the \`default\` filter runs. Without this every plugin author would need explicit \`{% if style.foo %}\` guards.
- **Compositor** builds a \`(plugin_instance_id → style_overrides)\` map per render and passes it into \`render_slot\`. At-most-one-Group invariant per plugin instance per layout (first-by-(z_index, id) wins on conflict — pinned by test).
- **\`spawn_children_from_manifest\`** learns \`kind: "plugin_slot"\` so un-decomposed-but-themable plugins can declare a single-element manifest. The Group is what holds \`style_overrides\`, even with one PluginSlot child.
- **Reference impl:** \`weather\` plugin gains \`temp_style\` (text_style) and \`accent_color\` (color); \`weather_full.html.liquid\` reads them via CSS custom properties with \`default(...)\` fallbacks.
- **plugin-authoring.md:** new "Theming knobs" section covering the field types, the split-storage rule, the "default filter is the single visual default" contract, and the \`kind = "plugin_slot"\` pattern.

### Tests (9 new in phase9_theming_tests.rs + 1 admin smoke)

- \`is_theme_field_type\` true/false table (positive cases + case-sensitivity + off-by-one).
- \`style_overrides\` round-trip on Group rows.
- Empty/None overrides round-trip as None (no \`{}\` wire bloat).
- Empty \`style\` doesn't break templates (Chainable + default filter end-to-end).
- Overrides actually apply when populated (CSS variable check on rendered HTML).
- Cross-layout isolation: same plugin instance, two layouts, distinct values — no leakage.
- Within-layout duplicate-Group ordering: lower z_index wins, alphabetic id breaks ties (contract-pinning).
- \`plugin_slot\` kind recognised in default_elements TOML deserialisation.
- Malformed JSON downgrades to None (forgiving contract).

## Phase 8b forward-port

Cherry-picked \`d4481db\` verbatim — the admin UI for the defaults-updated badge + Reset button. See the PR #11 description (already merged into the orphaned branch) for the original details. No changes from that commit; the only conflict was an additive smoke-test placement next to the new 9a smoke test.

## Test plan

- [x] \`cargo test\` — 514 tests pass (514 = previous 506 + 7 new phase9 tests + 1 phase9a admin smoke; the +7 to hit 514 from 506 includes the cherry-picked 8b smoke test that wasn't in main)
- [x] \`cargo clippy --locked -- -D warnings\` — clean (matches CI)
- [x] \`UndefinedBehavior::Chainable\` doesn't mask existing template errors (only theming chains use triple-attribute access; everything else uses single or two-deep with \`default(...)\` / \`{% if %}\` guards)
- [ ] Manual: drop weather plugin → save → curl GET /image.png → verify default colors render
- [ ] Manual: edit weather Group's \`style_overrides_json\` directly in the DB → reload → verify overrides apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)