### PR TITLE
feat(phase9b): admin UI for theming knobs (Plugin customization inspector)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1104,11 +1104,19 @@ struct LayoutSummary {
 }
 
 /// Plugin instance entry returned by `GET /api/admin/plugins`.
+///
+/// Phase 9b: `settings_schema` carries the plugin definition's declared
+/// fields so the admin "Plugin customization" inspector can render
+/// theming-knob controls (text_style / color / toggle) without a second
+/// roundtrip. Empty when the plugin definition is unknown to the registry
+/// (instance exists but the manifest was unloaded).
 #[derive(Debug, Serialize)]
 struct PluginInstanceSummary {
     id: String,
     name: String,
     supported_variants: Vec<&'static str>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    settings_schema: Vec<crate::plugin_registry::SettingsField>,
 }
 
 /// Body for `POST /api/admin/sources/:id/fields`.
@@ -1550,10 +1558,22 @@ async fn admin_list_plugins(
 
     let plugins: Vec<PluginInstanceSummary> = instances
         .into_iter()
-        .map(|inst| PluginInstanceSummary {
-            name: capitalize_first(&inst.plugin_id),
-            id: inst.id,
-            supported_variants: vec!["full", "half_horizontal", "half_vertical", "quadrant"],
+        .map(|inst| {
+            // Phase 9b: pull the plugin's settings_schema from the registry
+            // so the admin can render theming-knob controls without a
+            // second fetch. Unknown plugin → empty schema, which the UI
+            // treats as "no theming knobs declared."
+            let settings_schema = app
+                .plugin_registry
+                .get(&inst.plugin_id)
+                .map(|def| def.settings_schema)
+                .unwrap_or_default();
+            PluginInstanceSummary {
+                name: capitalize_first(&inst.plugin_id),
+                id: inst.id,
+                supported_variants: vec!["full", "half_horizontal", "half_vertical", "quadrant"],
+                settings_schema,
+            }
         })
         .collect();
 
@@ -4808,6 +4828,115 @@ mod tests {
         // itemsToPayload emission — Group-only.
         assert!(ADMIN_HTML.contains("isGroup ? (item.style_overrides || null)"),
                 "itemsToPayload missing style_overrides emission for Groups");
+    }
+
+    /// Phase 9b smoke test — asserts the inspector "Plugin customization"
+    /// section, the per-field-type renderers, the style-override mutation
+    /// helpers, and the JS-side theme-field discriminator are all wired
+    /// into the bundled admin template. Same partial-revert-catch
+    /// philosophy as 5b/6b/7b/8b.
+    #[test]
+    fn admin_html_contains_phase9b_markers() {
+        // Inspector section + dispatch.
+        assert!(ADMIN_HTML.contains("function pluginCustomizationSection"),
+                "missing pluginCustomizationSection builder");
+        assert!(ADMIN_HTML.contains("function isThemeFieldType"),
+                "missing JS-side isThemeFieldType discriminator");
+        assert!(ADMIN_HTML.contains("function pluginSchemaFor"),
+                "missing pluginSchemaFor lookup helper");
+        assert!(ADMIN_HTML.contains("Plugin customization</div>"),
+                "missing 'Plugin customization' section header");
+
+        // Per-field-type renderers.
+        assert!(ADMIN_HTML.contains("function colorKnobControl"),
+                "missing colorKnobControl renderer");
+        assert!(ADMIN_HTML.contains("function toggleKnobControl"),
+                "missing toggleKnobControl renderer");
+        assert!(ADMIN_HTML.contains("function textStyleKnobControl"),
+                "missing textStyleKnobControl renderer");
+
+        // Mutation helpers — single source of truth for style_overrides edits.
+        assert!(ADMIN_HTML.contains("function updateStyleOverride"),
+                "missing updateStyleOverride helper");
+        assert!(ADMIN_HTML.contains("function updateStyleSubkey"),
+                "missing updateStyleSubkey helper for text_style subfields");
+        assert!(ADMIN_HTML.contains("function toggleStyleSubkey"),
+                "missing toggleStyleSubkey helper for B/I/U buttons");
+        assert!(ADMIN_HTML.contains("function clearStyleOverride"),
+                "missing clearStyleOverride helper for the per-knob reset button");
+
+        // Section gated to plugin-bound Groups only.
+        assert!(ADMIN_HTML.contains("pluginCustomizationBlock"),
+                "renderProps missing pluginCustomizationBlock variable");
+    }
+
+    /// Phase 9b backend smoke test — `GET /api/admin/plugins` must include
+    /// `settings_schema` so the admin UI can render theming-knob controls
+    /// without a second roundtrip. Asserts the wire-shape extension.
+    #[tokio::test]
+    async fn admin_list_plugins_exposes_settings_schema() {
+        let (state, _dir) = make_writable_test_state();
+
+        // Register a plugin with one theming + one data field so we can
+        // verify both shapes survive the response.
+        use crate::plugin_registry::{DataStrategy, PluginDefinition, SettingsField};
+        let def = PluginDefinition {
+            id: "weather".to_string(),
+            name: "Weather".to_string(),
+            description: String::new(),
+            source: "weather".to_string(),
+            refresh_interval_secs: 300,
+            data_strategy: DataStrategy::Polling,
+            template_full: None,
+            template_half_horizontal: None,
+            template_half_vertical: None,
+            template_quadrant: None,
+            criteria: Vec::new(),
+            settings_schema: vec![
+                SettingsField {
+                    key: "station_id".to_string(),
+                    label: "Station ID".to_string(),
+                    field_type: "text".to_string(),
+                    required: false,
+                    placeholder: None,
+                    default: None,
+                },
+                SettingsField {
+                    key: "accent_color".to_string(),
+                    label: "Accent".to_string(),
+                    field_type: "color".to_string(),
+                    required: false,
+                    placeholder: None,
+                    default: None,
+                },
+            ],
+            default_elements: Vec::new(),
+        };
+        state.plugin_registry.insert(def);
+        let app = build_router(Arc::clone(&state));
+
+        let req = Request::builder()
+            .uri("/api/admin/plugins")
+            .header("x-api-key", "test-key")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        let weather = body.as_array().unwrap().iter()
+            .find(|p| p["id"] == "weather")
+            .expect("weather instance must be in the response");
+        let schema = weather["settings_schema"].as_array()
+            .expect("weather must carry settings_schema");
+        assert_eq!(schema.len(), 2, "expected 2 schema fields, got: {schema:?}");
+        // Theming fields use the same shape — admin UI dispatches on `type`.
+        let types: Vec<&str> = schema.iter()
+            .map(|f| f["type"].as_str().unwrap_or(""))
+            .collect();
+        assert!(types.contains(&"text"), "data type missing: {types:?}");
+        assert!(types.contains(&"color"), "theming type missing: {types:?}");
     }
 
     /// Phase 8b smoke test — asserts the inspector badge, banner, Reset

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -2525,6 +2525,14 @@ function renderProps() {
     (item.type === 'group' && item.plugin_id)
       ? pluginDefaultsSection(item)
       : '';
+  // Phase 9b: plugin-bound groups also get a "Plugin customization" section
+  // when the plugin's settings_schema declares any theming-typed fields
+  // (text_style / color / toggle). Section auto-hides for plugins that
+  // haven't opted in (no theming knobs declared).
+  const pluginCustomizationBlock =
+    (item.type === 'group' && item.plugin_id)
+      ? pluginCustomizationSection(item)
+      : '';
 
   const label = item.type === 'plugin_slot' ? (item.plugin_id || '?') + ' (plugin_slot)' : item.type;
   panel.innerHTML =
@@ -2540,6 +2548,7 @@ function renderProps() {
     iconMapBlock +
     conditionalSection +
     pluginDefaultsBlock +
+    pluginCustomizationBlock +
     '<div style="margin-top:10px; display: flex; gap: 6px; flex-wrap: wrap;">' +
       '<button class="btn" onclick="bringToFront()" title="Bring to front (top of stack)">⇈ Top</button>' +
       '<button class="btn" onclick="bringForward()" title="Bring forward one step">↑ Fwd</button>' +
@@ -2805,6 +2814,221 @@ async function onResetGroup() {
   } catch (e) {
     showToast('Reset error: ' + e.message, 'error');
   }
+}
+
+// ─── Phase 9b: plugin-customization section (theming knobs) ────────────────
+// Read the plugin's settings_schema (cached on the client; fetched lazily
+// alongside cachedPlugins). For each theming-typed field, render an inline
+// control. Edits write to item.style_overrides[knob_key] in-place; the
+// existing layout-save flow round-trips it to the server's Group row.
+
+// Mirror of `plugin_registry::is_theme_field_type`. The single source of
+// truth lives in Rust; this is the JS-side dispatch.
+function isThemeFieldType(t) {
+  return t === 'text_style' || t === 'color' || t === 'toggle';
+}
+
+// Find a plugin instance's schema in cachedPlugins. Returns [] when the
+// plugin is unknown (e.g. instance exists but the manifest was unloaded —
+// fail-closed: just don't show the customization UI).
+function pluginSchemaFor(pluginInstanceId) {
+  const p = cachedPlugins.find(function(x) { return x.id === pluginInstanceId; });
+  return (p && p.settings_schema) || [];
+}
+
+function pluginCustomizationSection(item) {
+  const schema = pluginSchemaFor(item.plugin_id);
+  const themeFields = schema.filter(function(f) { return isThemeFieldType(f.type); });
+  if (themeFields.length === 0) {
+    // Plugin author hasn't declared any theming knobs — section is silent.
+    // (Phase 9 scope: theming is opt-in, see plugin-authoring.md.)
+    return '';
+  }
+  const overrides = item.style_overrides || {};
+  const rows = themeFields.map(function(f) {
+    const val = overrides[f.key];
+    let control;
+    switch (f.type) {
+      case 'color':     control = colorKnobControl(f, val); break;
+      case 'toggle':    control = toggleKnobControl(f, val); break;
+      case 'text_style': control = textStyleKnobControl(f, val); break;
+      default:          control = '';
+    }
+    const isSet = val !== undefined && val !== null;
+    const clearBtn = isSet
+      ? '<button type="button" class="btn" ' +
+          'title="Reset to template default" ' +
+          'data-knob="' + esc(f.key) + '" ' +
+          'onclick="clearStyleOverride(this.dataset.knob)" ' +
+          'style="font-size:11px;padding:2px 8px;flex:0 0 auto">reset</button>'
+      : '';
+    return '<div class="pc-row" style="margin-bottom:10px">' +
+      '<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">' +
+        '<label style="font-size:12px;color:#c9d1d9;flex:1">' + esc(f.label) + '</label>' +
+        clearBtn +
+      '</div>' +
+      control +
+    '</div>';
+  }).join('');
+  return '<div class="plugin-customization-section" ' +
+      'style="margin-top:14px;padding-top:10px;border-top:1px solid #30363d">' +
+    '<div style="font-size:11px;color:#8b949e;text-transform:uppercase;' +
+      'letter-spacing:0.5px;margin-bottom:8px">Plugin customization</div>' +
+    rows +
+  '</div>';
+}
+
+// ─── Per-knob renderers ────────────────────────────────────────────────────
+
+// `color`: a CSS hex picker. Empty → falls back to the template's default.
+function colorKnobControl(field, value) {
+  const v = (typeof value === 'string' && value) ? value : '#000000';
+  return '<input type="color" value="' + esc(v) + '" ' +
+    'data-knob="' + esc(field.key) + '" ' +
+    'oninput="updateStyleOverride(this.dataset.knob, this.value)" ' +
+    'style="width:48px;height:28px;padding:0;border:1px solid #30363d;' +
+    'border-radius:4px;background:#21262d;cursor:pointer">';
+}
+
+// `toggle`: a checkbox. Coerces undefined to false so the checkbox state
+// is meaningful when no override is set.
+function toggleKnobControl(field, value) {
+  const checked = value === true ? ' checked' : '';
+  return '<label style="display:flex;align-items:center;gap:6px;font-size:12px;cursor:pointer">' +
+    '<input type="checkbox"' + checked + ' ' +
+      'data-knob="' + esc(field.key) + '" ' +
+      'onchange="updateStyleOverride(this.dataset.knob, this.checked)">' +
+    '<span style="color:#8b949e">' + (checked ? 'on' : 'off') + '</span>' +
+  '</label>';
+}
+
+// `text_style`: a flat bag of {family, size, weight, italic, underline, color}.
+// All subfields are optional; the template's default(...) filter fills blanks.
+// We render every subfield uniformly — plugin authors don't declare which
+// subfields are "exposed"; if they don't bind one in CSS, that's the same as
+// not exposing it. (See plugin-authoring.md → Theming → "Don't expose
+// subkeys you don't bind.")
+function textStyleKnobControl(field, value) {
+  const v = (value && typeof value === 'object') ? value : {};
+  const familyOpts = FONT_FAMILIES.map(function(f) {
+    return '<option value="' + esc(f.value) + '"' +
+      ((v.family || '') === f.value ? ' selected' : '') + '>' + esc(f.label) + '</option>';
+  }).join('');
+  const subBtn = function(sub, label, title) {
+    const pressed = !!v[sub];
+    const style = pressed
+      ? 'background:#58a6ff;color:#0d1117;font-weight:bold;'
+      : 'background:#21262d;color:#c9d1d9;';
+    return '<button type="button" title="' + title + '" ' +
+      'style="' + style + 'border:1px solid #30363d;border-radius:4px;' +
+      'padding:4px 8px;font-size:12px;cursor:pointer;min-width:28px;" ' +
+      'data-knob="' + esc(field.key) + '" data-sub="' + sub + '" ' +
+      'onclick="toggleStyleSubkey(this.dataset.knob, this.dataset.sub)">' + label + '</button>';
+  };
+  return '<div class="pc-text-style" style="display:grid;' +
+      'grid-template-columns:auto 1fr;gap:6px 8px;align-items:center;' +
+      'font-size:12px">' +
+    '<span style="color:#8b949e">Font</span>' +
+    '<select data-knob="' + esc(field.key) + '" data-sub="family" ' +
+      'onchange="updateStyleSubkey(this.dataset.knob, this.dataset.sub, this.value)">' +
+      familyOpts +
+    '</select>' +
+    '<span style="color:#8b949e">Size</span>' +
+    '<input type="number" min="8" max="200" ' +
+      'value="' + (v.size != null ? esc(v.size) : '') + '" ' +
+      'placeholder="auto" ' +
+      'data-knob="' + esc(field.key) + '" data-sub="size" ' +
+      'onchange="updateStyleSubkey(this.dataset.knob, this.dataset.sub, ' +
+        'this.value === \'\' ? null : +this.value)" ' +
+      'style="width:80px;padding:4px;background:#0d1117;color:#c9d1d9;' +
+      'border:1px solid #30363d;border-radius:4px">' +
+    '<span style="color:#8b949e">Style</span>' +
+    '<div style="display:flex;gap:4px">' +
+      subBtn('weight', '<b>B</b>', 'Bold (toggles weight: bold/normal)') +
+      subBtn('italic', '<i>I</i>', 'Italic') +
+      subBtn('underline', '<u>U</u>', 'Underline') +
+    '</div>' +
+    '<span style="color:#8b949e">Color</span>' +
+    '<input type="color" value="' + esc(v.color || '#000000') + '" ' +
+      'data-knob="' + esc(field.key) + '" data-sub="color" ' +
+      'oninput="updateStyleSubkey(this.dataset.knob, this.dataset.sub, this.value)" ' +
+      'style="width:48px;height:28px;padding:0;border:1px solid #30363d;' +
+      'border-radius:4px;background:#21262d;cursor:pointer">' +
+  '</div>';
+}
+
+// ─── Style-override mutation helpers ───────────────────────────────────────
+// Single source of truth for writing into item.style_overrides.
+// Renders inline so the user sees the change immediately; the existing
+// layout-save flow round-trips it on save.
+
+function updateStyleOverride(knob, value) {
+  const item = findItem(state.selectedId);
+  if (!item || item.type !== 'group') return;
+  if (!item.style_overrides) item.style_overrides = {};
+  item.style_overrides[knob] = value;
+  // No need to rerender the inspector — the input itself reflects the new
+  // value. The canvas doesn't show theming overrides at editing time
+  // (theming applies at compose time, not in the editor preview).
+}
+
+function updateStyleSubkey(knob, sub, value) {
+  const item = findItem(state.selectedId);
+  if (!item || item.type !== 'group') return;
+  if (!item.style_overrides) item.style_overrides = {};
+  if (!item.style_overrides[knob] || typeof item.style_overrides[knob] !== 'object') {
+    item.style_overrides[knob] = {};
+  }
+  if (value === null || value === '') {
+    delete item.style_overrides[knob][sub];
+    // Clean up empty parent objects so style_overrides doesn't accumulate
+    // {temp_style: {}} entries that round-trip but mean nothing.
+    if (Object.keys(item.style_overrides[knob]).length === 0) {
+      delete item.style_overrides[knob];
+    }
+  } else {
+    item.style_overrides[knob][sub] = value;
+  }
+}
+
+function toggleStyleSubkey(knob, sub) {
+  const item = findItem(state.selectedId);
+  if (!item || item.type !== 'group') return;
+  if (!item.style_overrides) item.style_overrides = {};
+  if (!item.style_overrides[knob] || typeof item.style_overrides[knob] !== 'object') {
+    item.style_overrides[knob] = {};
+  }
+  // For `weight`, toggle stores "bold" / "normal" — the template binds it
+  // verbatim into CSS. For italic/underline, store true / drop key.
+  if (sub === 'weight') {
+    const cur = item.style_overrides[knob].weight;
+    if (cur === 'bold') {
+      delete item.style_overrides[knob].weight;
+    } else {
+      item.style_overrides[knob].weight = 'bold';
+    }
+  } else {
+    if (item.style_overrides[knob][sub]) {
+      delete item.style_overrides[knob][sub];
+    } else {
+      item.style_overrides[knob][sub] = true;
+    }
+  }
+  if (Object.keys(item.style_overrides[knob]).length === 0) {
+    delete item.style_overrides[knob];
+  }
+  renderProps(); // toggle pressed-state needs the redraw
+}
+
+function clearStyleOverride(knob) {
+  const item = findItem(state.selectedId);
+  if (!item || item.type !== 'group') return;
+  if (!item.style_overrides) return;
+  delete item.style_overrides[knob];
+  if (Object.keys(item.style_overrides).length === 0) {
+    item.style_overrides = null;
+  }
+  renderProps();
 }
 
 // Sensible set of fonts for e-ink rendering.  Generic families first


### PR DESCRIPTION
## Summary

Phase 9b admin UI — wires the Phase 9a backend (PR #12) through the editor. **Targets PR #12's branch**; GitHub will auto-retarget to main when #12 merges.

- **Backend extension** — \`GET /api/admin/plugins\` gains a \`settings_schema\` field per instance, pulled from the plugin registry. The admin UI consumes it without a second roundtrip.
- **"Plugin customization" inspector section** — appears under the Group inspector, gated to plugin-bound Groups whose plugin declares any theming-typed fields (\`text_style\` / \`color\` / \`toggle\`). Plugins without theming knobs see no section — theming is opt-in per the Phase 9 design.
- **Three per-knob renderers**:
  - \`color\` — \`<input type="color">\`
  - \`toggle\` — checkbox
  - \`text_style\` — flat bag of {family, size, weight, italic, underline, color}; all optional. Bold/italic/underline as press-state buttons matching the existing \`textFormatFields\` pattern.
- **Mutation helpers** — \`updateStyleOverride\`, \`updateStyleSubkey\`, \`toggleStyleSubkey\`, \`clearStyleOverride\`. Single source of truth for writing into \`item.style_overrides\`. Empty subkey objects are pruned so the wire shape doesn't accumulate \`{temp_style: {}}\` noise.
- **\`isThemeFieldType\` JS-side mirror** of the Rust predicate. Comment in both places points to the other so the rule stays in sync.
- **Per-knob reset button** — clears just that knob's override; falls back to template default.

## Design notes

- **Canvas does NOT preview theming overrides.** They apply at compose time, not in the editor — same precedent as Phase 7 \`visible_when\` (which also doesn't preview in the canvas). The inspector reflects the current value but the geometry preview stays neutral.
- **Inline saves.** Edits write directly to \`state.items[i].style_overrides[knob_key]\` and are committed by the existing layout-save flow. No separate API endpoint.
- **Empty-state silence.** If the plugin has no theming-typed schema entries, the section is suppressed entirely (no "no knobs declared" placeholder). Reduces noise for plugins that haven't opted in.

## Test plan

- [x] \`cargo test\` — 518 tests pass (2 new: \`admin_html_contains_phase9b_markers\` + \`admin_list_plugins_exposes_settings_schema\`)
- [x] \`cargo clippy --locked -- -D warnings\` — clean (matches CI)
- [ ] Manual: select a plugin Group whose manifest declares a \`color\` knob → "Plugin customization" section appears → pick a color → save layout → curl GET /image.png → verify the override applies
- [ ] Manual: select a plugin Group whose manifest declares NO theming knobs → section is absent
- [ ] Manual: select a hand-built Group (no \`plugin_id\`) → section is absent
- [ ] Manual: \`text_style\` knob — set size=120, weight=bold → save → reload admin → verify subfields survive roundtrip
- [ ] Manual: per-knob reset button → clears just that knob → other knobs untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)