### PR TITLE
feat(editor): split-pane plugin template editor UI (PR C of 3)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -182,6 +182,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/admin", get(get_admin_ui))
         .route("/admin/login", post(post_admin_login))
         .route("/admin/logout", get(get_admin_logout))
+        .route("/admin/plugins/{id}/edit", get(get_plugin_editor_ui))
         .route("/api/admin/layouts", get(admin_list_layouts))
         .route("/api/admin/layout", post(admin_post_layout))
         .route("/api/admin/layout/{id}", get(admin_get_layout))
@@ -1241,7 +1242,76 @@ async fn get_admin_logout() -> impl IntoResponse {
         .unwrap()
 }
 
+/// `GET /admin/plugins/{id}/edit` — serve the split-pane plugin template
+/// editor (PR C). Reads `?variant=<name>` client-side; the route itself
+/// only needs the plugin id.
+///
+/// Auth: same model as `/admin` — requires the `cascades_admin_key`
+/// session cookie, otherwise redirects to `/admin` so the user can log
+/// in. The PR A preview endpoint and PR B source GET/PUT endpoints
+/// the page calls have their own auth gates, so the redirect is purely
+/// a UX nicety to avoid a half-rendered editor with broken fetches.
+///
+/// # XSS gating: id whitelist, not JSON encoding
+///
+/// The page injects the plugin id into a JavaScript `const` declaration
+/// in the served HTML. `serde_json::to_string` does NOT escape `<`, so
+/// an id of `</script><img src=x onerror=alert(1)>` would break out of
+/// the script context and execute attacker-controlled HTML. We gate
+/// this with [`is_valid_template_segment`] — the same `[A-Za-z0-9_-]`
+/// whitelist PR B's source GET/PUT use — so the only ids that reach
+/// the substitution are guaranteed to be HTML-safe by construction.
+/// Cookie-only auth means this is defence in depth (an attacker would
+/// already need the admin key), but rejecting unsafe ids costs one
+/// branch and matches the validation downstream API endpoints will
+/// apply anyway: a page that loads is guaranteed to be able to call
+/// the rest of the editor's endpoints.
+async fn get_plugin_editor_ui(
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    State(app): State<Arc<AppState>>,
+) -> Response<Body> {
+    if !is_admin_cookie_valid(&headers, &app.api_key) {
+        return Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(header::LOCATION, "/admin")
+            .body(Body::empty())
+            .unwrap();
+    }
+
+    // Reject ids that would HTML-break out of the const declaration the
+    // page injects them into (see the doc-comment above for the threat
+    // model). The same whitelist the PR B source GET/PUT endpoints use,
+    // so a successfully-loaded editor page is guaranteed to be able to
+    // talk to the underlying API endpoints.
+    if !is_valid_template_segment(&id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            "plugin id must match [A-Za-z0-9_-]{1,64}",
+        )
+            .into_response();
+    }
+
+    // After the whitelist, the id is ASCII-safe but we still JSON-encode
+    // it to keep the substitution a single, mechanical operation rather
+    // than a hand-crafted "splat the value into source" path. The
+    // placeholder includes the surrounding quotes so the result lands as
+    // a valid JSON string literal in the const declaration.
+    let id_json = serde_json::to_string(&id).unwrap_or_else(|_| "\"\"".to_string());
+    let html = PLUGIN_EDITOR_HTML.replace(
+        "\"__CASCADES_PLUGIN_ID_PLACEHOLDER__\"",
+        &id_json,
+    );
+
+    (
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        html,
+    )
+        .into_response()
+}
+
 const ADMIN_HTML: &str = include_str!("../templates/admin.html");
+const PLUGIN_EDITOR_HTML: &str = include_str!("../templates/admin_plugin_editor.html");
 
 const ADMIN_LOGIN_HTML: &str = r#"<!DOCTYPE html>
 <html lang="en">
@@ -6558,5 +6628,156 @@ mod tests {
         let response = app.oneshot(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE,
             "non-font bytes claiming to be a font must be rejected");
+    }
+
+    // ── PR C: GET /admin/plugins/{id}/edit ───────────────────────────────────
+
+    /// Construct an authenticated request to the editor route. Used by the
+    /// auth/HTML-shape tests below. Cookie auth mirrors the real admin SPA.
+    fn editor_req(plugin_id: &str, with_cookie: bool) -> Request<Body> {
+        let mut b = Request::builder()
+            .uri(format!("/admin/plugins/{plugin_id}/edit"));
+        if with_cookie {
+            b = b.header(header::COOKIE, "cascades_admin_key=test-key");
+        }
+        b.body(Body::empty()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn plugin_editor_unauth_redirects_to_admin() {
+        let (state, _dir) = make_writable_test_state();
+        let app = build_router(Arc::clone(&state));
+        let response = app.oneshot(editor_req("weather", false)).await.unwrap();
+        // Without the session cookie we redirect to /admin (where the user
+        // can log in), instead of returning 401 — the editor is a browser
+        // surface, not a programmatic API.
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        let location = response
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(location, "/admin");
+    }
+
+    #[tokio::test]
+    async fn plugin_editor_authed_returns_html_with_plugin_id_baked_in() {
+        let (state, _dir) = make_writable_test_state();
+        let app = build_router(Arc::clone(&state));
+        let response = app.oneshot(editor_req("weather", true)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let ct = response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(ct.contains("text/html"), "expected text/html, got {ct}");
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body = std::str::from_utf8(&bytes).unwrap();
+
+        // The placeholder marker must have been replaced with a JSON literal
+        // — and the literal must reflect the path-segment id.
+        assert!(
+            !body.contains("__CASCADES_PLUGIN_ID_PLACEHOLDER__"),
+            "placeholder must be substituted before serving"
+        );
+        assert!(
+            body.contains(r#"const PLUGIN_ID = "weather""#),
+            "expected baked-in plugin id, got page body of {} bytes",
+            body.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn plugin_editor_html_carries_phase_c_markers() {
+        // Smoke test on the embedded HTML — guards "someone reverted half
+        // the file" without needing a browser harness. Match strings are
+        // specific enough that a typo or partial revert would break them.
+        assert!(
+            PLUGIN_EDITOR_HTML.contains("Plugin template editor"),
+            "missing page title"
+        );
+        assert!(
+            PLUGIN_EDITOR_HTML.contains("/api/admin/template/preview"),
+            "preview endpoint URL missing — page won't fetch previews"
+        );
+        assert!(
+            PLUGIN_EDITOR_HTML.contains("/api/admin/plugins/"),
+            "source GET/PUT base URL missing"
+        );
+        assert!(
+            PLUGIN_EDITOR_HTML.contains("PREVIEW_DEBOUNCE_MS"),
+            "debounce constant missing — preview-on-keystroke would fire on every char"
+        );
+        assert!(
+            PLUGIN_EDITOR_HTML.contains("\"__CASCADES_PLUGIN_ID_PLACEHOLDER__\""),
+            "placeholder marker missing — server-side substitution would fail silently"
+        );
+        assert!(
+            PLUGIN_EDITOR_HTML.contains("highlightGutterError"),
+            "error-line gutter helper missing"
+        );
+        assert!(
+            PLUGIN_EDITOR_HTML.contains("Ctrl+S"),
+            "save shortcut hint missing — minor but a regression alert"
+        );
+    }
+
+    #[tokio::test]
+    async fn plugin_editor_rejects_ids_with_quotes() {
+        // An id with quotes can't pass the [A-Za-z0-9_-] whitelist, so the
+        // handler should refuse before serving the page. This guards the
+        // const-declaration string-context — a quote-bearing id would
+        // otherwise need ad-hoc escaping. (`serde_json::to_string` does
+        // escape `"`, but we don't rely on that — the whitelist is the
+        // gate, see the handler's doc-comment.)
+        let (state, _dir) = make_writable_test_state();
+        let app = build_router(Arc::clone(&state));
+        let req = Request::builder()
+            .uri("/admin/plugins/we%22ather/edit")
+            .header(header::COOKIE, "cascades_admin_key=test-key")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn plugin_editor_rejects_ids_that_could_break_out_of_script_tag() {
+        // `</script>` is the canonical "HTML-context-breaking" payload —
+        // `serde_json::to_string` does NOT escape `<` (RFC 8259 doesn't
+        // require it), so without the whitelist a malicious id like
+        // `</script><img src=x onerror=alert(1)>` would land verbatim in
+        // the const declaration and execute. Cookie-only auth gates
+        // exploitation, but defence in depth costs one branch.
+        let (state, _dir) = make_writable_test_state();
+        let app = build_router(Arc::clone(&state));
+        let req = Request::builder()
+            // URL-encoded `</script>` — matchit lets it through as raw
+            // bytes, then our whitelist rejects.
+            .uri("/admin/plugins/%3C%2Fscript%3E/edit")
+            .header(header::COOKIE, "cascades_admin_key=test-key")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn admin_spa_links_to_plugin_editor() {
+        // Smoke check — a future revert that drops the editor link from
+        // `buildPalette` would silently strip the discovery path. Cheap
+        // insurance: the URL prefix has to stay in admin.html.
+        assert!(
+            ADMIN_HTML.contains("/admin/plugins/"),
+            "admin SPA palette must link to /admin/plugins/{{id}}/edit"
+        );
+        assert!(
+            ADMIN_HTML.contains("title=\"Edit ")
+                || ADMIN_HTML.contains("/edit\""),
+            "expected an `edit` button rendering in admin.html palette"
+        );
     }
 }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1686,10 +1686,16 @@ function buildPalette(plugins) {
     }).join('');
     var browseBtn = '<button class="variant-btn" onclick="event.stopPropagation();openJsonExplorer(\'' +
       safeId + '\')" title="Browse JSON fields for ' + safeName + '">\uD83D\uDD0D fields</button>';
+    // PR C: link to the split-pane template editor for this plugin. Opens
+    // in a new tab so the layout work-in-progress isn't lost.
+    var editBtn = '<a class="variant-btn" target="_blank" rel="noopener"' +
+      ' onclick="event.stopPropagation()" href="/admin/plugins/' +
+      encodeURIComponent(safeId) + '/edit"' +
+      ' title="Edit ' + safeName + ' templates">✎ edit</a>';
     return '<div class="palette-item" draggable="true"' +
       ' ondragstart="onPaletteDragStart(event,{type:\'plugin\',id:\'' + safeId + '\',variant:\'full\'})">' +
       '<div class="palette-item-name">' + safeName + '</div>' +
-      '<div class="palette-variants">' + variants + ' ' + browseBtn + '</div></div>';
+      '<div class="palette-variants">' + variants + ' ' + browseBtn + ' ' + editBtn + '</div></div>';
   }).join('');
 }
 

--- a/templates/admin_plugin_editor.html
+++ b/templates/admin_plugin_editor.html
@@ -1,0 +1,711 @@
+<!DOCTYPE html>
+<!--
+  Cascades plugin template editor (PR C — split-pane editor on top of the
+  PR A preview endpoint and the PR B source GET/PUT endpoints).
+
+  Layout (CSS grid):
+    ┌──────────────┬─────────────────────────┐
+    │              │   live preview (PNG)    │
+    │   editor     ├─────────────────────────┤
+    │              │   sample-data JSON      │
+    └──────────────┴─────────────────────────┘
+
+  Auth model: same as `/admin` — relies on the `cascades_admin_key`
+  session cookie being set, with a one-shot redirect to /admin if it
+  isn't. The handler in `api.rs` performs the cookie check before
+  serving this HTML; this page itself trusts that gate.
+
+  Self-contained: no external CDNs, no build step. Plain `<textarea>`
+  for both editors keeps the page in line with the project's "no
+  vendored JS" convention. CodeMirror or Monaco can be layered on later
+  by swapping the textarea innards without changing the surrounding
+  request flow.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Plugin template editor — Cascades</title>
+  <style>
+    /* Reset + dark theme matching admin.html. */
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      color: #e6edf3;
+      background: #0d1117;
+      display: flex;
+      flex-direction: column;
+    }
+    code, pre, textarea {
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      gap: .75rem;
+      padding: .5rem .75rem;
+      background: #161b22;
+      border-bottom: 1px solid #30363d;
+      flex: 0 0 auto;
+    }
+    header a.back {
+      color: #79c0ff;
+      text-decoration: none;
+      font-size: 1.1rem;
+      padding: 0 .25rem;
+    }
+    header a.back:hover { text-decoration: underline; }
+    header .plugin-id {
+      font-weight: 600;
+      font-family: ui-monospace, monospace;
+      color: #e6edf3;
+    }
+    header .variants {
+      display: flex;
+      gap: .25rem;
+      margin-left: 1rem;
+    }
+    header .variants button {
+      background: transparent;
+      color: #8b949e;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: .25rem .6rem;
+      font: inherit;
+      cursor: pointer;
+    }
+    header .variants button:hover {
+      background: #21262d;
+      color: #e6edf3;
+    }
+    header .variants button.active {
+      background: #1f6feb;
+      color: #fff;
+      border-color: #1f6feb;
+    }
+    header .variants button.dirty::after {
+      content: " •";
+      color: #f0883e;
+    }
+    header .spacer { flex: 1; }
+    header .status {
+      font-size: 12px;
+      color: #8b949e;
+      min-width: 6rem;
+      text-align: right;
+    }
+    header .status.ok    { color: #56d364; }
+    header .status.error { color: #f85149; }
+    header button.save {
+      background: #238636;
+      color: #fff;
+      border: 1px solid #2ea043;
+      border-radius: 4px;
+      padding: .35rem .9rem;
+      font: inherit;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    header button.save:disabled {
+      background: #30363d;
+      color: #6e7681;
+      border-color: #30363d;
+      cursor: not-allowed;
+    }
+    header button.save:hover:not(:disabled) { background: #2ea043; }
+
+    main {
+      flex: 1 1 auto;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      grid-template-areas:
+        "editor preview"
+        "editor data";
+      gap: 1px;
+      background: #30363d;
+      min-height: 0;
+    }
+    section {
+      background: #0d1117;
+      display: flex;
+      flex-direction: column;
+      min-height: 0;
+      min-width: 0;
+    }
+    .pane-header {
+      flex: 0 0 auto;
+      padding: .35rem .75rem;
+      background: #161b22;
+      border-bottom: 1px solid #30363d;
+      font-size: 11px;
+      text-transform: uppercase;
+      color: #8b949e;
+      letter-spacing: .04em;
+      display: flex;
+      align-items: center;
+      gap: .5rem;
+    }
+    .pane-header .hint {
+      color: #6e7681;
+      text-transform: none;
+      font-size: 11px;
+      letter-spacing: 0;
+    }
+
+    /* ── Editor pane (Jinja source) ───────────────────────────── */
+    .editor-pane { grid-area: editor; }
+    .editor-wrap {
+      flex: 1 1 auto;
+      display: flex;
+      min-height: 0;
+      position: relative;
+    }
+    .gutter {
+      flex: 0 0 auto;
+      padding: .5rem .35rem .5rem .5rem;
+      background: #0d1117;
+      color: #6e7681;
+      font: 13px/1.4 ui-monospace, monospace;
+      text-align: right;
+      user-select: none;
+      white-space: pre;
+      border-right: 1px solid #21262d;
+      overflow: hidden;
+    }
+    .gutter .err-line {
+      color: #f85149;
+      font-weight: 700;
+    }
+    textarea#editor, textarea#data-editor {
+      flex: 1 1 auto;
+      width: 100%;
+      background: #0d1117;
+      color: #e6edf3;
+      border: 0;
+      padding: .5rem .5rem .5rem .5rem;
+      resize: none;
+      outline: none;
+      tab-size: 2;
+      line-height: 1.4;
+      font-size: 13px;
+      white-space: pre;
+      overflow: auto;
+    }
+    textarea#editor:focus, textarea#data-editor:focus {
+      background: #0d1117;
+    }
+
+    /* ── Preview pane ─────────────────────────────────────────── */
+    .preview-pane { grid-area: preview; }
+    .preview-body {
+      flex: 1 1 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background:
+        repeating-conic-gradient(#21262d 0% 25%, #161b22 0% 50%) 50% / 16px 16px;
+      padding: 1rem;
+      overflow: auto;
+      min-height: 0;
+    }
+    img#preview-img {
+      max-width: 100%;
+      max-height: 100%;
+      background: #fff;
+      border: 1px solid #30363d;
+      box-shadow: 0 2px 6px rgba(0,0,0,.4);
+    }
+    img#preview-img.stale { opacity: .55; transition: opacity .15s; }
+    .error-banner {
+      background: #2d1212;
+      color: #ffa198;
+      border-top: 1px solid #6e2222;
+      padding: .5rem .75rem;
+      font-family: ui-monospace, monospace;
+      font-size: 12px;
+      white-space: pre-wrap;
+    }
+    .error-banner .stage {
+      display: inline-block;
+      background: #6e2222;
+      color: #ffd0cc;
+      padding: 0 .35rem;
+      border-radius: 3px;
+      margin-right: .35rem;
+      text-transform: uppercase;
+      font-size: 10px;
+      letter-spacing: .04em;
+    }
+    .error-banner .where {
+      color: #ff7b72;
+      font-weight: 600;
+    }
+    .error-banner[hidden] { display: none; }
+
+    /* ── Data pane (sample JSON) ─────────────────────────────── */
+    .data-pane { grid-area: data; }
+    .data-pane textarea#data-editor {
+      padding-left: .75rem;
+    }
+    .data-pane .data-error {
+      flex: 0 0 auto;
+      background: #2d1212;
+      color: #ffa198;
+      border-top: 1px solid #6e2222;
+      padding: .35rem .75rem;
+      font-family: ui-monospace, monospace;
+      font-size: 11px;
+    }
+    .data-pane .data-error[hidden] { display: none; }
+  </style>
+</head>
+<body>
+
+<header>
+  <a href="/admin" class="back" title="Back to admin">←</a>
+  <span class="plugin-id" id="plugin-id"></span>
+  <nav class="variants" id="variants"></nav>
+  <span class="spacer"></span>
+  <span class="status" id="status">loading…</span>
+  <button class="save" id="save-btn" disabled>Save</button>
+</header>
+
+<main>
+  <section class="editor-pane">
+    <div class="pane-header">
+      template source <span class="hint">Jinja2 — Ctrl+S to save</span>
+    </div>
+    <div class="editor-wrap">
+      <div class="gutter" id="gutter"></div>
+      <textarea id="editor" spellcheck="false" autocomplete="off"
+                placeholder="Loading…"></textarea>
+    </div>
+  </section>
+
+  <section class="preview-pane">
+    <div class="pane-header">live preview <span class="hint" id="preview-dim"></span></div>
+    <div class="preview-body">
+      <img id="preview-img" alt="">
+    </div>
+    <div class="error-banner" id="error-banner" hidden></div>
+  </section>
+
+  <section class="data-pane">
+    <div class="pane-header">
+      sample data <span class="hint">JSON object — surfaces as <code>data</code> in the template</span>
+    </div>
+    <textarea id="data-editor" spellcheck="false" autocomplete="off"
+              placeholder='{}'>{}</textarea>
+    <div class="data-error" id="data-error" hidden></div>
+  </section>
+</main>
+
+<script>
+'use strict';
+
+// ─────────────────────────────────────────────────────────────────────────
+// State + URL helpers
+// ─────────────────────────────────────────────────────────────────────────
+
+// Plugin id is injected by the server-side handler via a unique-string
+// substitution: the server replaces the JSON literal below with the
+// `serde_json::to_string`'d id. Keeps the id out of the URL-trust path
+// (the URL was already validated by the route matcher, but the JSON
+// round-trip means even a hostile id can't escape its string context).
+const PLUGIN_ID = "__CASCADES_PLUGIN_ID_PLACEHOLDER__";
+
+function urlVariant() {
+  const u = new URL(window.location.href);
+  return u.searchParams.get('variant') || 'full';
+}
+
+function setUrlVariant(variant) {
+  const u = new URL(window.location.href);
+  u.searchParams.set('variant', variant);
+  history.replaceState(null, '', u.toString());
+}
+
+// Per-variant in-memory state. Lets us flip variant tabs without losing
+// in-flight edits to the others.
+//   { sourceOnDisk, currentSource, sampleData (string), dirty: bool }
+const variantState = new Map();
+
+function ensureVariantState(name) {
+  if (!variantState.has(name)) {
+    variantState.set(name, {
+      sourceOnDisk: '',
+      currentSource: '',
+      sampleData: '{}',
+      dirty: false,
+    });
+  }
+  return variantState.get(name);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// API
+// ─────────────────────────────────────────────────────────────────────────
+
+function apiFetch(url, opts) {
+  const o = opts || {};
+  const baseHeaders = (o.body instanceof FormData)
+    ? {}
+    : { 'Content-Type': 'application/json' };
+  const headers = Object.assign(baseHeaders, o.headers || {});
+  return fetch(url, Object.assign({}, o, { headers, credentials: 'same-origin' }));
+}
+
+async function fetchSource(variant) {
+  const url = '/api/admin/plugins/' + encodeURIComponent(PLUGIN_ID)
+            + '/source/' + encodeURIComponent(variant);
+  const res = await apiFetch(url);
+  if (!res.ok) throw new Error('GET ' + url + ' → ' + res.status);
+  return res.json();
+}
+
+async function previewTemplate(templateSource, contextData, variant) {
+  const body = {
+    template_source: templateSource,
+    variant: variant,
+  };
+  if (contextData !== undefined) body.context = { data: contextData };
+  const res = await apiFetch('/api/admin/template/preview', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  if (res.ok) {
+    const blob = await res.blob();
+    return { ok: true, blob };
+  }
+  // Both 4xx and 5xx return JSON error bodies (PR A's TemplatePreviewError).
+  let payload = null;
+  try { payload = await res.json(); } catch (_) { /* malformed body, ignore */ }
+  return { ok: false, status: res.status, error: payload };
+}
+
+async function saveSource(variant, templateSource) {
+  const url = '/api/admin/plugins/' + encodeURIComponent(PLUGIN_ID)
+            + '/source/' + encodeURIComponent(variant);
+  const res = await apiFetch(url, {
+    method: 'PUT',
+    body: JSON.stringify({ template_source: templateSource }),
+  });
+  if (res.ok) return { ok: true, body: await res.json() };
+  let payload = null;
+  try { payload = await res.json(); } catch (_) { /* malformed body */ }
+  return { ok: false, status: res.status, error: payload };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// DOM
+// ─────────────────────────────────────────────────────────────────────────
+
+const elPluginId    = document.getElementById('plugin-id');
+const elVariants    = document.getElementById('variants');
+const elStatus      = document.getElementById('status');
+const elSaveBtn     = document.getElementById('save-btn');
+const elEditor      = document.getElementById('editor');
+const elGutter      = document.getElementById('gutter');
+const elDataEditor  = document.getElementById('data-editor');
+const elDataError   = document.getElementById('data-error');
+const elPreviewImg  = document.getElementById('preview-img');
+const elPreviewDim  = document.getElementById('preview-dim');
+const elErrorBanner = document.getElementById('error-banner');
+
+elPluginId.textContent = PLUGIN_ID;
+
+// ─────────────────────────────────────────────────────────────────────────
+// Status pill
+// ─────────────────────────────────────────────────────────────────────────
+
+let statusTimer = null;
+function setStatus(text, kind) {
+  elStatus.textContent = text || '';
+  elStatus.className = 'status ' + (kind || '');
+  clearTimeout(statusTimer);
+  if (text && (kind === 'ok')) {
+    statusTimer = setTimeout(() => {
+      if (elStatus.textContent === text) {
+        elStatus.textContent = '';
+        elStatus.className = 'status';
+      }
+    }, 1500);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Variant tabs
+// ─────────────────────────────────────────────────────────────────────────
+
+let activeVariant = urlVariant();
+let availableVariants = [activeVariant];
+
+function renderVariants() {
+  elVariants.innerHTML = '';
+  for (const v of availableVariants) {
+    const btn = document.createElement('button');
+    btn.dataset.variant = v;
+    btn.textContent = v;
+    if (v === activeVariant) btn.classList.add('active');
+    if (variantState.get(v)?.dirty) btn.classList.add('dirty');
+    btn.addEventListener('click', () => switchVariant(v));
+    elVariants.appendChild(btn);
+  }
+}
+
+async function switchVariant(v) {
+  if (v === activeVariant) return;
+  // Save in-memory edits before flipping.
+  saveVariantBufferToState(activeVariant);
+  activeVariant = v;
+  setUrlVariant(v);
+  renderVariants();
+  await loadVariantIntoEditor(v);
+  await schedulePreview(0);
+}
+
+function saveVariantBufferToState(v) {
+  const st = ensureVariantState(v);
+  st.currentSource = elEditor.value;
+  st.sampleData = elDataEditor.value;
+  st.dirty = (st.currentSource !== st.sourceOnDisk);
+}
+
+async function loadVariantIntoEditor(v) {
+  const st = ensureVariantState(v);
+  // Lazy-fetch on first visit to avoid pulling sources for variants the
+  // user never opens.
+  if (st.sourceOnDisk === '' && st.currentSource === '') {
+    setStatus('loading ' + v + '…');
+    try {
+      const got = await fetchSource(v);
+      st.sourceOnDisk = got.template_source;
+      st.currentSource = got.template_source;
+      // Only update the available-variants list if the server gave us a
+      // populated one; first-page-load already seeded it.
+      if (Array.isArray(got.available_variants) && got.available_variants.length > 0) {
+        availableVariants = got.available_variants;
+        renderVariants();
+      }
+    } catch (e) {
+      setStatus('failed to load: ' + e.message, 'error');
+    }
+  }
+  elEditor.value = st.currentSource;
+  elDataEditor.value = st.sampleData;
+  refreshGutter();
+  updateSaveButton();
+  setStatus('');
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Editor wiring
+// ─────────────────────────────────────────────────────────────────────────
+
+let previewTimer = null;
+const PREVIEW_DEBOUNCE_MS = 200;
+
+function schedulePreview(delay) {
+  clearTimeout(previewTimer);
+  return new Promise(resolve => {
+    previewTimer = setTimeout(async () => {
+      await runPreview();
+      resolve();
+    }, delay !== undefined ? delay : PREVIEW_DEBOUNCE_MS);
+  });
+}
+
+let lastPreviewBlobUrl = null;
+
+function showPreviewBlob(blob) {
+  // Revoke the previous URL to avoid leaking object URLs across edits.
+  if (lastPreviewBlobUrl) URL.revokeObjectURL(lastPreviewBlobUrl);
+  lastPreviewBlobUrl = URL.createObjectURL(blob);
+  elPreviewImg.src = lastPreviewBlobUrl;
+  elPreviewImg.classList.remove('stale');
+}
+
+function showPreviewError(status, payload) {
+  // Mark the existing image stale so the user can see what the previous
+  // good render looked like while reading the error.
+  elPreviewImg.classList.add('stale');
+  const stage = (payload && payload.stage) || 'error';
+  const line = (payload && payload.line) ? ('line ' + payload.line) : '';
+  const errMsg = (payload && payload.error) || ('HTTP ' + status);
+  elErrorBanner.innerHTML = '';
+  const stageEl = document.createElement('span');
+  stageEl.className = 'stage';
+  stageEl.textContent = stage;
+  elErrorBanner.appendChild(stageEl);
+  if (line) {
+    const where = document.createElement('span');
+    where.className = 'where';
+    where.textContent = line + ': ';
+    elErrorBanner.appendChild(where);
+  }
+  elErrorBanner.appendChild(document.createTextNode(errMsg));
+  elErrorBanner.hidden = false;
+  highlightGutterError(payload && payload.line);
+}
+
+function clearPreviewError() {
+  elErrorBanner.hidden = true;
+  elErrorBanner.textContent = '';
+  highlightGutterError(null);
+}
+
+async function runPreview() {
+  const source = elEditor.value;
+  let contextData;
+  try {
+    const trimmed = elDataEditor.value.trim();
+    contextData = trimmed === '' ? {} : JSON.parse(trimmed);
+    elDataError.hidden = true;
+  } catch (e) {
+    elDataError.textContent = 'sample data: ' + e.message;
+    elDataError.hidden = false;
+    contextData = {};
+  }
+  const result = await previewTemplate(source, contextData, activeVariant);
+  if (result.ok) {
+    showPreviewBlob(result.blob);
+    clearPreviewError();
+  } else {
+    showPreviewError(result.status, result.error);
+  }
+}
+
+elEditor.addEventListener('input', () => {
+  const st = ensureVariantState(activeVariant);
+  st.currentSource = elEditor.value;
+  st.dirty = (st.currentSource !== st.sourceOnDisk);
+  refreshGutter();
+  updateSaveButton();
+  renderVariants();
+  schedulePreview();
+});
+
+elDataEditor.addEventListener('input', () => {
+  ensureVariantState(activeVariant).sampleData = elDataEditor.value;
+  schedulePreview();
+});
+
+// Tab key inserts two spaces instead of moving focus — bare textareas
+// otherwise lose tab to the browser's tab-out behaviour.
+elEditor.addEventListener('keydown', (e) => {
+  if (e.key === 'Tab' && !e.shiftKey) {
+    e.preventDefault();
+    const start = elEditor.selectionStart;
+    const end = elEditor.selectionEnd;
+    elEditor.value =
+      elEditor.value.substring(0, start) + '  ' + elEditor.value.substring(end);
+    elEditor.selectionStart = elEditor.selectionEnd = start + 2;
+    elEditor.dispatchEvent(new Event('input'));
+  }
+});
+
+// Ctrl/Cmd-S saves.
+window.addEventListener('keydown', (e) => {
+  if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+    e.preventDefault();
+    onSave();
+  }
+});
+
+elSaveBtn.addEventListener('click', () => onSave());
+
+// ─────────────────────────────────────────────────────────────────────────
+// Save
+// ─────────────────────────────────────────────────────────────────────────
+
+async function onSave() {
+  const st = ensureVariantState(activeVariant);
+  if (!st.dirty) return;
+  setStatus('saving…');
+  elSaveBtn.disabled = true;
+  const result = await saveSource(activeVariant, st.currentSource);
+  if (result.ok) {
+    st.sourceOnDisk = st.currentSource;
+    st.dirty = false;
+    setStatus('saved ' + (result.body?.bytes_written ?? '0') + ' bytes', 'ok');
+    updateSaveButton();
+    renderVariants();
+  } else {
+    // 422 means the new source didn't parse; the engine + disk are
+    // unchanged. The preview banner already shows the line for the
+    // typed-but-not-saved source, so we mirror it via the status pill
+    // rather than blowing it away.
+    const msg = (result.error?.error) || ('HTTP ' + result.status);
+    setStatus('save failed: ' + msg, 'error');
+    elSaveBtn.disabled = false;
+  }
+}
+
+function updateSaveButton() {
+  const st = variantState.get(activeVariant);
+  elSaveBtn.disabled = !(st && st.dirty);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Gutter (line numbers + error highlight)
+// ─────────────────────────────────────────────────────────────────────────
+
+let errorLine = null;
+
+function refreshGutter() {
+  const lines = elEditor.value.split('\n').length;
+  const out = [];
+  for (let i = 1; i <= lines; i++) {
+    if (i === errorLine) {
+      out.push('<span class="err-line">' + i + '</span>');
+    } else {
+      out.push('' + i);
+    }
+  }
+  elGutter.innerHTML = out.join('\n');
+}
+
+function highlightGutterError(line) {
+  errorLine = (typeof line === 'number' && line > 0) ? line : null;
+  refreshGutter();
+}
+
+// Keep the gutter scroll aligned with the textarea.
+elEditor.addEventListener('scroll', () => {
+  elGutter.scrollTop = elEditor.scrollTop;
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Boot
+// ─────────────────────────────────────────────────────────────────────────
+
+async function boot() {
+  setStatus('loading…');
+  try {
+    const got = await fetchSource(activeVariant);
+    const st = ensureVariantState(activeVariant);
+    st.sourceOnDisk = got.template_source;
+    st.currentSource = got.template_source;
+    if (Array.isArray(got.available_variants) && got.available_variants.length > 0) {
+      availableVariants = got.available_variants;
+    }
+    renderVariants();
+    elEditor.value = st.currentSource;
+    elDataEditor.value = st.sampleData;
+    refreshGutter();
+    updateSaveButton();
+    elPreviewDim.textContent = activeVariant;
+    setStatus('');
+    await schedulePreview(0);
+  } catch (e) {
+    setStatus('failed to load: ' + e.message, 'error');
+  }
+}
+
+boot();
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Closes the plugin-editor work. New page at `/admin/plugins/{id}/edit` combines the PR A preview endpoint (#16) and the PR B source GET/PUT endpoints (#17) into a live-editing surface.
- Three-pane layout: source editor (left), live preview PNG (top-right), sample-data JSON editor (bottom-right). Variant tabs swap full / half_horizontal / half_vertical / quadrant for the same plugin without losing in-flight edits.
- 200ms debounce on every keystroke; Jinja errors render with stage tag + line number in a red banner and a red line in the gutter; last-good preview stays at 55% opacity for reference.
- Existing admin SPA gets an "✎ edit" link next to each plugin in the palette — opens the editor in a new tab so layout WIP isn't lost.

This is **PR C of three** for the plugin editor:

| PR | Status |
|----|--------|
| A — `POST /api/admin/template/preview` | merged in #16 |
| B — source `GET`/`PUT` + template hot-reload | merged in #17 |
| **C (this)** — split-pane editor UI |

## Editor choice: plain `<textarea>`, not CodeMirror

Deliberate. The project convention is zero external CDNs and no build step — `admin.html` is ~4400 lines of self-contained JS + CSS today. Pulling in CodeMirror via CDN would break that, and vendoring a minified bundle is a separate decision the project hasn't made. The textarea handles tab-to-2-spaces, has a line-number gutter that highlights the error line, and syncs scroll. Documented in HTML comments — swapping in CodeMirror or Monaco later only touches the editor pane internals, not the request flow.

## XSS gate is the id whitelist, NOT the JSON encoding

Caught by advisor review pre-commit: `serde_json::to_string` does NOT escape `<` (RFC 8259 doesn't require it). Without a whitelist, an id like `</script><img src=x onerror=alert(1)>` would land verbatim in the page's `const PLUGIN_ID = ...` declaration, break out of the script tag, and execute attacker HTML.

Fix: the handler runs `is_valid_template_segment` (the `[A-Za-z0-9_-]{1,64}` regex PR B already uses for source GET/PUT) before substituting. A page that loads is guaranteed to be able to call the rest of the editor's endpoints — single source of truth on what an id can contain.

Cookie-only auth means an attacker would already need the admin key to exploit this, so it's defense in depth — but it's one branch and avoids ad-hoc HTML escaping.

Tests added: `plugin_editor_rejects_ids_with_quotes` and `plugin_editor_rejects_ids_that_could_break_out_of_script_tag`.

## Page-injection mechanism

The HTML carries a unique-string placeholder `"__CASCADES_PLUGIN_ID_PLACEHOLDER__"` (including surrounding quotes); the server replaces it with `serde_json::to_string(&id)` so the substitution lands as a valid JSON string literal in `const PLUGIN_ID = ...;`. The marker can't accidentally match anywhere else in the embedded HTML.

## Test plan

- [x] `cargo test --lib plugin_editor` — 6 endpoint tests:
  - unauth-redirects-to-/admin
  - authed-returns-HTML-with-baked-id
  - all PR-C JS markers present (preview URL, source URL, debounce constant, gutter helper, save shortcut, placeholder marker)
  - ids-with-quotes rejected
  - ids-with-`</script>` rejected
- [x] `cargo test --lib admin_spa_links_to_plugin_editor` — guards the link in `buildPalette` against silent revert
- [x] `cargo test --lib --tests` — 456 lib tests + all 9 integration test binaries green
- [x] `cargo clippy --lib --tests` — clean for changed files (3 remaining warnings are pre-existing in unrelated code)
- [ ] Manual smoke (will run before merge):
  - Boot server + sidecar, log in via `/admin`, click "✎ edit" on Weather → editor loads with `weather_full` source visible
  - Edit `{{ data.temp }}` → preview re-renders within ~200ms
  - Inject `{% if true %` (unclosed) → red banner with "parse" stage + line 1; gutter line 1 turns red; last-good preview stays at 55% opacity
  - Switch variant tab → loads the source for that variant, preview re-renders at the new dimensions
  - Edit + save (Cmd+S) → status pill flashes "saved N bytes", file on disk reflects the change, `/image.png` (in another tab) reflects the change immediately

## Variant cursor/scroll position lost on tab switch

Minor UX thing surfaced in advisor review — switching variants resets cursor + scroll within each variant's textarea on the *first* visit (subsequent visits use the cached `currentSource` so the value is preserved, but cursor isn't). Fixable later with a per-variant `selectionStart/End` cache; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)