### PR TITLE
ci: cross-compile gate for aarch64-linux + Makefile guidance update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,3 +35,52 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --locked -- -D warnings
+
+  cross-build-arm64:
+    # Cross-compile gate: catches regressions that break the Pi target
+    # (the deploy path for `make install`) without us having to wait for a
+    # ~50-minute build on a Pi Zero 2 W to fail. Independent of the test
+    # job — a regression in either should fail loudly without blocking
+    # the other.
+    name: Cross-build (aarch64-linux-gnu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cross
+        # taiki-e/install-action grabs a prebuilt cross binary in seconds
+        # vs ~3 min for `cargo install`. CI runs on x86_64 Linux where
+        # the upstream crates.io 0.2.5 release works fine. Apple Silicon
+        # operators should follow the Makefile's recommendation
+        # (`cargo install cross --git`) instead — the crates.io build is
+        # broken on aarch64 hosts (cross-rs/cross#1628).
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Cache cargo registry + cross target dir
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/aarch64-unknown-linux-gnu
+          key: ${{ runner.os }}-cross-aarch64-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cross-aarch64-
+
+      - name: Cross build (release)
+        run: cross build --release --target aarch64-unknown-linux-gnu --locked
+
+      - name: Verify binary is aarch64-linux ELF
+        # `file` reports "ARM aarch64" for the right output. Anything else
+        # means cross silently fell back to native cargo (which it warns
+        # about but doesn't fail on) and we'd have shipped an x86_64
+        # binary to a Pi.
+        run: |
+          BIN=target/aarch64-unknown-linux-gnu/release/cascades
+          file "$BIN"
+          file "$BIN" | grep -q "ARM aarch64"
+          echo "✓ aarch64 binary verified ($(stat -c%s "$BIN") bytes)"

--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,25 @@ build: ## Build the release binary (the one the installer copies to the Pi)
 	@printf "\n✓ Binary: target/release/cascades\n"
 
 .PHONY: build-arm64
-build-arm64: ## Cross-compile for aarch64 (Pi 4/5) — requires `cross`
+build-arm64: ## Cross-compile for aarch64-linux (Pi) — needs `cross` + Docker
 	@command -v cross >/dev/null 2>&1 || { \
-		echo "cross not found. Install with: cargo install cross --git https://github.com/cross-rs/cross"; \
+		echo "cross not found."; \
+		echo "  Apple Silicon: cargo install cross --git https://github.com/cross-rs/cross --locked"; \
+		echo "                 (the crates.io 0.2.5 release is broken on aarch64 hosts —"; \
+		echo "                  see https://github.com/cross-rs/cross/issues/1628)"; \
+		echo "  x86_64 Linux:  cargo install cross --locked"; \
+		exit 1; \
+	}
+	@docker info >/dev/null 2>&1 || { \
+		echo "Docker daemon not running. Start Docker Desktop / colima / podman first."; \
 		exit 1; \
 	}
 	cross build --release --target aarch64-unknown-linux-gnu
 	@printf "\n✓ ARM64 binary: target/aarch64-unknown-linux-gnu/release/cascades\n"
-	@printf "  (when running install.sh, copy this binary to target/release/cascades on the Pi first)\n"
+	@printf "  Ship to the Pi:\n"
+	@printf "    scp target/aarch64-unknown-linux-gnu/release/cascades \\\\\n"
+	@printf "        jackellis@<pi-host>:/srv/cascades/target/release/cascades\n"
+	@printf "  Then on the Pi: sudo ./scripts/install.sh\n"
 
 # ─── Install / uninstall ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two related changes from today's deploy session:

1. **CI gate** — adds a `cross-build-arm64` job to `.github/workflows/rust.yml` that does `cross build --release --target aarch64-unknown-linux-gnu` on every push/PR. Catches a broken Pi-deploy path in **~3 min on CI** rather than ~50 min on a Pi Zero 2 W during an actual deploy.
2. **Makefile guidance** — updated `make build-arm64`'s install hint to call out the Apple-Silicon trap that bit me earlier today.

## CI gate details

- **Independent job**, not chained off `test`. ARM build doesn't need the x86_64 test results, and a regression in either should fail loudly without blocking the other.
- **`taiki-e/install-action@v2`** grabs a prebuilt `cross` binary in seconds vs ~3 min for `cargo install`. CI runs on x86_64 Linux where the upstream crates.io 0.2.5 release works fine — the Apple-Silicon bug ([cross-rs/cross#1628](https://github.com/cross-rs/cross/issues/1628)) doesn't apply.
- **Asserts the output is actually aarch64 ELF.** `cross` silently falls back to native cargo if its container can't start (warned but not failed). Without the `file | grep -q "ARM aarch64"` check, we'd happily ship an x86_64 binary to a Pi.
- **Caches `~/.cargo/registry`, `~/.cargo/git`, and `target/aarch64-unknown-linux-gnu`** keyed on `Cargo.lock` hash — keeps re-runs cheap.

## Makefile change

`make build-arm64` now:

- Refuses to run if `cross` is missing, with platform-specific install instructions:
  - Apple Silicon: `cargo install cross --git https://github.com/cross-rs/cross --locked` (the only thing that works — flagged the crates.io trap explicitly)
  - x86_64 Linux: `cargo install cross --locked`
- Refuses to run if Docker daemon isn't responding (was a confusing failure mode mid-pull before)
- Prints the exact `scp` command for shipping the binary to the Pi at `/srv/cascades/target/release/cascades` (matches what `install.sh` expects)

## Why this matters now

Today I tried to build cascades natively on the user's Pi Zero 2 W (416 MiB RAM). Build was healthy but ~30+ min in with another 20+ to go. Cross-compiled the same binary on my Mac in **1 min 28 s**, scp'd it over, validated it ran. The deploy went from "wait 50 min and pray" to "wait 90 s and ship." This PR makes that the documented and CI-enforced path.

## Test plan

- [x] `make build-arm64` invokes `cross` correctly (verified locally — same binary that's running on the Pi right now)
- [x] YAML parses (ruby's YAML.safe_load)
- [ ] CI run on this PR — first invocation will validate the workflow + cache key
- [ ] Future regression test: revert one of the fixes that landed earlier (e.g. break the editor route), confirm `cross-build-arm64` fails alongside `test`

Stacks behind PR #20 (server-only installer cleanup) — the two are independent file-wise but #20's the one being deployed. Either order of merge is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)