### PR TITLE
fix(deploy): use system chromium for Puppeteer (fixes ENOEXEC on aarch64)

### DIFF
--- a/docs/deploying-on-raspberry-pi.md
+++ b/docs/deploying-on-raspberry-pi.md
@@ -172,6 +172,13 @@ Almost always a missing Chromium runtime lib. `journalctl -u
 cascades-sidecar` will show which `.so` the dynamic loader couldn't find;
 add to `APT_PKGS` in `scripts/install.sh` and re-run `make install`.
 
+**`/image.png` returns 500 with `ENOEXEC` in the sidecar log**
+You're on an old install (before PR #22) where Puppeteer downloaded a
+Linux-x64 Chrome binary that can't run on aarch64. Re-run `make install`
+to pick up the apt-`chromium` + `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium`
+fix. The stale download under `/home/cascades/.cache/puppeteer/` can be
+deleted to reclaim ~150MB; the new install path doesn't use it.
+
 **`cargo build --release` is OOM'ing on a small Pi**
 Pi Zero 2 W has 416 MB of RAM. Use:
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -117,11 +117,20 @@ step "Installing system packages"
 
 # Idempotent: apt-get skips already-installed packages.
 APT_PKGS=(
-    # Chromium runtime deps that Puppeteer's bundled Chromium needs.
-    # Without these the sidecar starts but every render fails with cryptic
-    # SIGSEGV / shared-library errors. Bookworm and Trixie both ship the
-    # un-suffixed names below as installable (Trixie also offers `*t64`
-    # transitional packages but doesn't require them).
+    # The system Chromium binary itself. We point Puppeteer at this
+    # (PUPPETEER_EXECUTABLE_PATH below + in the sidecar systemd unit)
+    # instead of letting Puppeteer download its own. Two reasons:
+    # 1. Puppeteer 22.x only ships a Linux-x64 Chrome binary — running
+    #    it on aarch64 fails posix_spawn with ENOEXEC. The apt package
+    #    is built for the host's arch, so this works on Pi (arm64) and
+    #    NUCs/VMs (x86_64) alike.
+    # 2. Saves ~150MB of download per install + matches the convention
+    #    on Raspberry Pi OS where chromium is the standard browser.
+    chromium
+    # Chromium's runtime shared-library deps. Listed explicitly even
+    # though `chromium` pulls most of them in — keeps the install
+    # deterministic and gives clean apt errors if a future Debian
+    # release drops one.
     libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 libxkbcommon0
     libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0
     libcairo2 libasound2 libxss1 libgtk-3-0 fonts-liberation
@@ -235,11 +244,16 @@ step "Installing sidecar dependencies (downloads ARM64 Chromium — slow first t
 
 # --frozen-lockfile keeps repeated installs deterministic — refuses to
 # install if bun.lock would need updating. The repo ships a checked-in
-# lockfile for exactly this reason. (`install.sh` excludes the lockfile
-# from rsync but `bun install` writes it back when satisfied.)
+# lockfile for exactly this reason.
+#
+# PUPPETEER_SKIP_DOWNLOAD=true tells Puppeteer's postinstall not to
+# fetch its bundled Chrome — we use the apt `chromium` package above
+# (see PUPPETEER_EXECUTABLE_PATH in the sidecar systemd unit). Skips
+# a ~150MB download and avoids the Puppeteer-22.x-only-ships-x64
+# trap on aarch64.
 as_service_user bash -c \
-    "cd '${INSTALL_DIR}/sidecar' && '${BUN_BIN}' install --frozen-lockfile"
-log "Sidecar deps installed"
+    "cd '${INSTALL_DIR}/sidecar' && PUPPETEER_SKIP_DOWNLOAD=true '${BUN_BIN}' install --frozen-lockfile"
+log "Sidecar deps installed (Puppeteer Chrome download skipped — using apt chromium)"
 
 # ─── Step 6: systemd units ────────────────────────────────────────────────
 

--- a/scripts/systemd/cascades-sidecar.service
+++ b/scripts/systemd/cascades-sidecar.service
@@ -19,6 +19,14 @@ Environment=RENDER_PORT=3001
 # Where the install.sh script puts Bun. Could also be /usr/local/bin/bun if
 # bun was installed system-wide.
 Environment=PATH=/home/cascades/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# Tell Puppeteer to use the system Chromium (apt-installed by install.sh)
+# instead of its own bundled binary. Puppeteer 22.x only ships a Linux-x64
+# Chrome download — running it on aarch64 fails posix_spawn with ENOEXEC.
+# The apt package is built for the host arch, so this works on Pi (arm64)
+# and NUCs/VMs (x86_64) alike. install.sh sets PUPPETEER_SKIP_DOWNLOAD
+# during `bun install` to skip the ~150MB download Puppeteer would
+# otherwise do.
+Environment=PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 ExecStart=/home/cascades/.bun/bin/bun server.ts
 
 # Chromium spawns a few subprocesses per render; let it.


### PR DESCRIPTION
## Summary

Live deploy on a Pi Zero 2 W today hit a wall: every `/image.png` request returned 500 with this in `journalctl -u cascades-sidecar`:

```
ENOEXEC: unknown error, posix_spawn '/home/cascades/.cache/puppeteer/chrome/linux-127.0.6533.88/chrome-linux64/chrome'
```

**Root cause**: Puppeteer 22.x only ships a Linux-**x64** Chrome binary in its postinstall download. On aarch64 the bundled binary can't execute. (Puppeteer's own arm64 support has been "coming soon" for years.)

**Fix**: install the apt `chromium` package (built for the host arch — arm64 on Pi, amd64 on NUC/VM, so the one fix covers everything), point Puppeteer at it via `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium`, and skip Puppeteer's own ~150MB postinstall download with `PUPPETEER_SKIP_DOWNLOAD=true`.

## Three pieces

| File | Change |
|---|---|
| `scripts/install.sh` | Added `chromium` to `APT_PKGS` |
| `scripts/install.sh` | `PUPPETEER_SKIP_DOWNLOAD=true` on the `bun install` command |
| `scripts/systemd/cascades-sidecar.service` | `Environment=PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium` |
| `docs/deploying-on-raspberry-pi.md` | New troubleshooting entry for the ENOEXEC symptom on pre-PR-#22 installs |

## Convergence from PR #19/#20

Re-running `make install` on a host with the broken bundled Chrome will: install the apt chromium, restart the sidecar with the new env, and start serving. The stale `~/.cache/puppeteer/chrome/...` x64 binary stays on disk (~150 MB wasted) — documented in the troubleshooting note as a manual `rm -rf` to reclaim space. Not worth automating because it touches the service user's home dir.

## Validated live

Manual fix applied via `systemctl edit cascades-sidecar` on `flats.mnmlst.cc` this afternoon:

```
HTTP 200  ct=image/png  size=5019  time=59.358s   ← cold (Chromium boot on 416MB Pi)
HTTP 200  size=5019  time=0.067s                  ← warm
HTTP 200  size=5019  time=0.001s                  ← cached
```

This PR bakes the same fix into the installer so the next deploy doesn't hit it.

## Test plan

- [x] Apt `chromium` is available on Bookworm + Trixie (verified in earlier probe)
- [x] PUPPETEER_EXECUTABLE_PATH override works (today's drop-in proves it)
- [x] PUPPETEER_SKIP_DOWNLOAD=true skips the postinstall (Puppeteer-22 documented behavior)
- [x] CI's existing tests + the cross-build gate (PR #21) cover anything Rust-side that could regress
- [ ] Re-run `make install` on `flats.mnmlst.cc` after merge — should be a no-op aside from the systemd unit getting the new Environment= line and a sidecar restart

## Stack of open PRs

| # | Title | State |
|---|---|---|
| #21 | cross-compile CI gate + Makefile guidance | open |
| **#22** (this) | use system chromium for Puppeteer | open |

Independent file-wise, can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)